### PR TITLE
Add battery monitor daily stats via LoRa

### DIFF
--- a/esp32-c3-receiver/include/receiver.h
+++ b/esp32-c3-receiver/include/receiver.h
@@ -23,6 +23,7 @@ class Receiver : public Device
     unsigned int getSendStatusFrequency() const { return statusSendFreqSec; }
 
     void sendStatus();
+    void sendDailyStats();
 
     private:
     void sendHello();
@@ -46,6 +47,7 @@ class Receiver : public Device
     int txPower = TX_OUTPUT_POWER;
     unsigned int statusSendFreqSec = DEFAULT_STATUS_SEND_FREQ_SEC;
     unsigned long lastStatusSend = 0;
+    bool pendingDailyStats = false;
     bool mIsTransmitting = false;
     void sendAck(char *rxpacket);
     void setRelayState(bool newRelayState);

--- a/heltec-controller-receiver/include/controller.h
+++ b/heltec-controller-receiver/include/controller.h
@@ -10,6 +10,8 @@
 #include "device-config.h"
 #include "settings.h"
 
+struct DailyStats;
+
 enum RelayState
 {
     UNKNOWN,
@@ -68,6 +70,7 @@ private:
 
     void publishControllerStatus();
     void publishReceiverStatus(int power, int rssi, int snr, bool relay, bool pulse, int battery);
+    void publishReceiverDailyStats(const struct DailyStats &stats);
 
     void setSendStatusFrequency(unsigned int freq);
     unsigned int getSendStatusFrequency() const { return statusSendFreqSec; }


### PR DESCRIPTION
## Summary
- send BatteryMonitor daily statistics from the ESP32 C3 receiver
- forward receiver battery daily stats via MQTT in controller
- expose new Home Assistant sensor for receiver battery daily stats

## Testing
- `pio run` in `esp32-c3-receiver`
- `pio run` in `heltec-controller-receiver`


------
https://chatgpt.com/codex/tasks/task_e_688d69a41e88832bb2e8d85b4345e0b8