### PR TITLE
Add battery state to receiver status reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,9 @@ It exposes a `switch` entity for basic on/off control and `number` entities name
 `Pump Pulse`, `Controller Tx Power` and `Receiver Tx Power`.
 It also publishes `sensor` entities `Controller Status` and `Receiver Status`
 which report the JSON data sent to `pump_station/status/controller` and
-`pump_station/status/receiver`.
+`pump_station/status/receiver`. The receiver status now also includes
+`low` and `full` battery flags along with a `charge` state of
+`CHARGING`, `DISCHARGING` or `STABLE`.
 The controller enforces a minimum transmit power defined by `MIN_TX_OUTPUT_POWER`.
 
 On boot the controller sends a `STATUS` request to the receiver. The receiver

--- a/esp32-c3-receiver/src/BatteryMonitor.cpp
+++ b/esp32-c3-receiver/src/BatteryMonitor.cpp
@@ -82,6 +82,31 @@ void BatteryMonitor::setCalibrationFactor(float factor) {
     _calibrationFactor = factor;
 }
 
+void BatteryMonitor::setLowThreshold(float voltage) {
+    _lowThreshold = voltage;
+}
+
+void BatteryMonitor::setHighThreshold(float voltage) {
+    _highThreshold = voltage;
+}
+
+bool BatteryMonitor::isLow() const {
+    return getVoltage() <= _lowThreshold;
+}
+
+bool BatteryMonitor::isFull() const {
+    return getVoltage() >= _highThreshold;
+}
+
+void BatteryMonitor::setVoltageRange(float vEmpty, float vFull) {
+    _vEmpty = vEmpty;
+    _vFull = vFull;
+}
+
+ChargeState BatteryMonitor::getChargeState() const {
+    return _chargeState;
+}
+
 void BatteryMonitor::update() {
     float reading = takeSingleReading();
     _sampleBuffer[_sampleIndex] = reading;

--- a/esp32-c3-receiver/src/receiver.cpp
+++ b/esp32-c3-receiver/src/receiver.cpp
@@ -424,7 +424,10 @@ void Receiver::sendHello()
 void Receiver::sendStatus()
 {
     int b = (int) battery.getPercentage();
-    sprintf(txpacket, "S:%d:%d:%d:%d:%d:%d", txPower, mLastRssi, mLastSnr, mRelayState ? 1 : 0, mPulseMode ? 1 : 0, b);
+    int low = battery.isLow() ? 1 : 0;
+    int full = battery.isFull() ? 1 : 0;
+    int state = static_cast<int>(battery.getChargeState());
+    sprintf(txpacket, "S:%d:%d:%d:%d:%d:%d:%d:%d:%d", txPower, mLastRssi, mLastSnr, mRelayState ? 1 : 0, mPulseMode ? 1 : 0, b, low, full, state);
 
     pendingDailyStats = true;
     send(txpacket, strlen(txpacket));

--- a/heltec-controller-receiver/include/controller.h
+++ b/heltec-controller-receiver/include/controller.h
@@ -69,7 +69,8 @@ private:
     void pulseRelay(unsigned int onTime);
 
     void publishControllerStatus();
-    void publishReceiverStatus(int power, int rssi, int snr, bool relay, bool pulse, int battery);
+    void publishReceiverStatus(int power, int rssi, int snr, bool relay, bool pulse, int battery,
+                               bool low, bool full, int chargeState);
     void publishReceiverDailyStats(const struct DailyStats &stats);
 
     void setSendStatusFrequency(unsigned int freq);


### PR DESCRIPTION
## Summary
- extend C3 receiver status message with low/full flags and charge state
- expose battery thresholds and charge state helpers in `BatteryMonitor`
- parse and publish new battery fields to MQTT on the controller

## Testing
- `cd esp32-c3-receiver && pio run`
- `cd heltec-controller-receiver && cp include/config-example.h include/config.h && pio run`


------
https://chatgpt.com/codex/tasks/task_e_688d84cbecb4832b8cf42bd6faedcfca