### PR TITLE
Improve battery charge state detection

### DIFF
--- a/esp32-c3-receiver/include/BatteryMonitor.h
+++ b/esp32-c3-receiver/include/BatteryMonitor.h
@@ -86,6 +86,11 @@ private:
     float _vFull;
 
     mutable ChargeState _chargeState;
+    ChargeState _pendingState;
+    int _stateStreak;
+    float _emaShort;
+    float _emaLong;
+    bool _emaInitialized;
 
     bool _ucVoltage;
     bool _ucLinearPct;


### PR DESCRIPTION
## Summary
- smooth voltage readings with short and long term exponential averages
- debounce charge state changes to avoid rapid oscillations

## Testing
- `pio run`


------
https://chatgpt.com/codex/tasks/task_e_688d9af7f66c832ba9ed44b0ec2de400