### PR TITLE
Add OTA WiFi activation via MQTT

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Flash the compiled firmware to two boards. Set `isController` as required before
 - `pump_station/switch/pulse` – payload is a number of seconds to turn the relay on once. The controller sends a `PULSE` LoRa message containing the duration and also publishes an `OFF` message when the time expires.
 - `pump_station/tx_power/controller/set` – integer transmit power in dBm for the controller.
 - `pump_station/tx_power/receiver/set` – integer transmit power in dBm for the receiver.
+- `pump_station/wifi/connect` – ask the receiver to join the default WiFi network and enable OTA updates.
+- `pump_station/wifi/connect_custom` – payload `SSID:PASSWORD` to join a specific network for OTA.
 
 ### Home Assistant Discovery
 

--- a/esp32-c3-receiver/include/device-config.h
+++ b/esp32-c3-receiver/include/device-config.h
@@ -33,7 +33,7 @@
 
 
 #define RX_TIMEOUT_VALUE                            1000
-#define BUFFER_SIZE                                 30 // Define the payload size here
+#define BUFFER_SIZE                                 128 // Define the payload size here
 
 // Default number of seconds the receiver will remain ON if
 // no further ON commands are received.

--- a/esp32-c3-receiver/include/receiver.h
+++ b/esp32-c3-receiver/include/receiver.h
@@ -54,6 +54,8 @@ class Receiver : public Device
     void processReceived(char *rxpacket);
     void send(char *packet, size_t len);
     void actuateRelay(bool state);
+    void connectWifi(const char *ssid, const char *pass);
+    bool otaEnabled = false;
 
 
 

--- a/heltec-controller-receiver/include/device-config.h
+++ b/heltec-controller-receiver/include/device-config.h
@@ -33,7 +33,7 @@
 
 
 #define RX_TIMEOUT_VALUE                            1000
-#define BUFFER_SIZE                                 30 // Define the payload size here
+#define BUFFER_SIZE                                 128 // Define the payload size here
 
 // Default number of seconds the receiver will remain ON if
 // no further ON commands are received.


### PR DESCRIPTION
## Summary
- allow controller to forward MQTT `wifi` commands to receiver
- receiver can connect to WiFi and start ArduinoOTA for updates
- enlarge LoRa buffer to carry WiFi credentials and document new topics

## Testing
- `python3 -m platformio run -d heltec-controller-receiver` *(fails: MQTT_USER/WIFI_SSID undefined, missing intelhex)*
- `python3 -m platformio run -d esp32-c3-receiver` *(fails: WIFI_SSID undefined, missing intelhex)*

------
https://chatgpt.com/codex/tasks/task_e_688d9f261368832b8a2391837a0748aa