### PR TITLE
Add WiFi status reporting

### DIFF
--- a/esp32-c3-receiver/include/device-config.h
+++ b/esp32-c3-receiver/include/device-config.h
@@ -58,4 +58,11 @@
 // Digital pin indicating charge status (HIGH when charging)
 #define CHARGE_STATUS_PIN 34
 
+enum WifiStatus {
+    WIFI_DISABLED,
+    WIFI_CONNECTED,
+    WIFI_CONNECTING,
+    WIFI_ERROR
+};
+
 #endif

--- a/esp32-c3-receiver/src/receiver.cpp
+++ b/esp32-c3-receiver/src/receiver.cpp
@@ -431,7 +431,24 @@ void Receiver::sendStatus()
     int low = battery.isLow() ? 1 : 0;
     int full = battery.isFull() ? 1 : 0;
     int state = static_cast<int>(battery.getChargeState());
-    sprintf(txpacket, "S:%d:%d:%d:%d:%d:%d:%d:%d:%d", txPower, mLastRssi, mLastSnr, mRelayState ? 1 : 0, mPulseMode ? 1 : 0, b, low, full, state);
+    int wifi = WIFI_DISABLED;
+    if (WiFi.getMode() != WIFI_MODE_NULL)
+    {
+        wl_status_t st = WiFi.status();
+        if (st == WL_CONNECTED)
+        {
+            wifi = WIFI_CONNECTED;
+        }
+        else if (st == WL_DISCONNECTED || st == WL_IDLE_STATUS)
+        {
+            wifi = WIFI_CONNECTING;
+        }
+        else
+        {
+            wifi = WIFI_ERROR;
+        }
+    }
+    sprintf(txpacket, "S:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d", txPower, mLastRssi, mLastSnr, mRelayState ? 1 : 0, mPulseMode ? 1 : 0, b, low, full, state, wifi);
 
     pendingDailyStats = true;
     send(txpacket, strlen(txpacket));

--- a/heltec-controller-receiver/include/controller.h
+++ b/heltec-controller-receiver/include/controller.h
@@ -70,7 +70,7 @@ private:
 
     void publishControllerStatus();
     void publishReceiverStatus(int power, int rssi, int snr, bool relay, bool pulse, int battery,
-                               bool low, bool full, int chargeState);
+                               bool low, bool full, int chargeState, int wifi);
     void publishReceiverDailyStats(const struct DailyStats &stats);
 
     void setSendStatusFrequency(unsigned int freq);

--- a/heltec-controller-receiver/include/device-config.h
+++ b/heltec-controller-receiver/include/device-config.h
@@ -58,4 +58,11 @@
 // Digital pin indicating charge status (HIGH when charging)
 #define CHARGE_STATUS_PIN 34
 
+enum WifiStatus {
+    WIFI_DISABLED,
+    WIFI_CONNECTED,
+    WIFI_CONNECTING,
+    WIFI_ERROR
+};
+
 #endif

--- a/heltec-controller-receiver/src/receiver.cpp
+++ b/heltec-controller-receiver/src/receiver.cpp
@@ -200,7 +200,24 @@ void Receiver::sendHello()
 void Receiver::sendStatus()
 {
     int battery = mBattery.getPercentage();
-    sprintf(txpacket, "S:%d:%d:%d:%d:%d:%d", txPower, mLastRssi, mLastSnr, mRelayState ? 1 : 0, mPulseMode ? 1 : 0, battery);
+    int wifi = WIFI_DISABLED;
+    if (mWifiEnabled)
+    {
+        wl_status_t st = WiFi.status();
+        if (st == WL_CONNECTED)
+        {
+            wifi = WIFI_CONNECTED;
+        }
+        else if (st == WL_DISCONNECTED || st == WL_IDLE_STATUS)
+        {
+            wifi = WIFI_CONNECTING;
+        }
+        else
+        {
+            wifi = WIFI_ERROR;
+        }
+    }
+    sprintf(txpacket, "S:%d:%d:%d:%d:%d:%d:%d", txPower, mLastRssi, mLastSnr, mRelayState ? 1 : 0, mPulseMode ? 1 : 0, battery, wifi);
     Serial.printf("Sending status \"%s\", length %d\r\n", txpacket, strlen(txpacket));
     lora_idle = false;
     Radio.Send((uint8_t *)txpacket, strlen(txpacket));


### PR DESCRIPTION
## Summary
- add WiFi status enum constants
- include WiFi connection state in receiver status messages
- publish receiver WiFi status via MQTT

## Testing
- `pio run` (heltec-controller-receiver) *(fails: MQTT_USER not declared)*
- `pio run` (esp32-c3-receiver) *(fails: missing config-private.h)*

------
https://chatgpt.com/codex/tasks/task_e_688dab94f31c832ba95570e481925eac