### PR TITLE
Enable disabling receiver WiFi via MQTT

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Flash the compiled firmware to two boards. Set `isController` as required before
 - `pump_station/tx_power/receiver/set` – integer transmit power in dBm for the receiver.
 - `pump_station/wifi/connect` – ask the receiver to join the default WiFi network and enable OTA updates.
 - `pump_station/wifi/connect_custom` – payload `SSID:PASSWORD` to join a specific network for OTA.
+- `pump_station/wifi/disable` – disconnect the receiver from WiFi and disable OTA updates.
 
 ### Home Assistant Discovery
 

--- a/esp32-c3-receiver/include/receiver.h
+++ b/esp32-c3-receiver/include/receiver.h
@@ -55,6 +55,7 @@ class Receiver : public Device
     void send(char *packet, size_t len);
     void actuateRelay(bool state);
     void connectWifi(const char *ssid, const char *pass);
+    void disableWifi();
     bool otaEnabled = false;
 
 

--- a/esp32-c3-receiver/src/receiver.cpp
+++ b/esp32-c3-receiver/src/receiver.cpp
@@ -600,6 +600,18 @@ void Receiver::connectWifi(const char *ssid, const char *pass)
     }
 }
 
+void Receiver::disableWifi()
+{
+    Serial.println("Disabling WiFi and OTA");
+    WiFi.disconnect(true);
+    WiFi.mode(WIFI_MODE_NULL);
+    if (otaEnabled)
+    {
+        ArduinoOTA.end();
+        otaEnabled = false;
+    }
+}
+
 void Receiver::processReceived(char *rxpacket)
 {
     char *strings[10];
@@ -640,9 +652,13 @@ void Receiver::processReceived(char *rxpacket)
             int power = atoi(strings[3]);
             setTxPower(power);
         } else if(strcasecmp(strings[2], "wifi") == 0) {
-            const char *ssid = (index >= 4) ? strings[3] : WIFI_SSID;
-            const char *pass = (index >= 5) ? strings[4] : WIFI_PASS;
-            connectWifi(ssid, pass);
+            if (index >= 4 && strcasecmp(strings[3], "off") == 0) {
+                disableWifi();
+            } else {
+                const char *ssid = (index >= 4) ? strings[3] : WIFI_SSID;
+                const char *pass = (index >= 5) ? strings[4] : WIFI_PASS;
+                connectWifi(ssid, pass);
+            }
         } else {
             bool newRelayState = false;
             if(strcasecmp(strings[2], "on") == 0 || strcasecmp(strings[2], "pulse") == 0) {

--- a/heltec-controller-receiver/src/controller.cpp
+++ b/heltec-controller-receiver/src/controller.cpp
@@ -260,6 +260,9 @@ void Controller::mqttCallback(char *topic, byte *payload, unsigned int length) {
             ++mStateId;
             sendMessage(msg);
         }
+    } else if(strcmp(topic, "pump_station/wifi/disable") == 0) {
+        ++mStateId;
+        sendMessage("WIFI:OFF");
     } else if(strcmp(topic, "pump_station/switch/state") == 0) {
         initialStateReceived = true;
         retainedStateOn = cmd.startsWith("ON");
@@ -354,6 +357,7 @@ void Controller::ensureMqtt() {
     mqttClient.subscribe("pump_station/status_freq/receiver/set");
     mqttClient.subscribe("pump_station/wifi/connect");
     mqttClient.subscribe("pump_station/wifi/connect_custom");
+    mqttClient.subscribe("pump_station/wifi/disable");
     mqttClient.subscribe("pump_station/switch/state");
 
     // Process any retained messages (such as the last set command or state)


### PR DESCRIPTION
## Summary
- Allow controller to publish `WIFI:OFF` over LoRa when `pump_station/wifi/disable` MQTT topic is received
- Receiver now supports `wifi off` command to disconnect WiFi/OTA
- Document new `pump_station/wifi/disable` MQTT topic

## Testing
- `pio run` in `heltec-controller-receiver`
- `pio run` in `esp32-c3-receiver`


------
https://chatgpt.com/codex/tasks/task_e_688db9aa3d8c832bb22e336e8627e811