### PR TITLE
Remove redundant battery status flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,8 @@ It exposes a `switch` entity for basic on/off control and `number` entities name
 `Pump Pulse`, `Controller Tx Power` and `Receiver Tx Power`.
 It also publishes `sensor` entities `Controller Status` and `Receiver Status`
 which report the JSON data sent to `pump_station/status/controller` and
-`pump_station/status/receiver`. The receiver status now also includes
-`low` and `full` battery flags along with a `charge` state of
-`CHARGING`, `DISCHARGING` or `STABLE`.
+`pump_station/status/receiver`. The receiver status now includes a battery
+percentage and a `charge` state of `CHARGING`, `DISCHARGING` or `STABLE`.
 The controller enforces a minimum transmit power defined by `MIN_TX_OUTPUT_POWER`.
 
 On boot the controller sends a `STATUS` request to the receiver. The receiver

--- a/esp32-c3-receiver/src/receiver.cpp
+++ b/esp32-c3-receiver/src/receiver.cpp
@@ -428,8 +428,6 @@ void Receiver::sendHello()
 void Receiver::sendStatus()
 {
     int b = (int) battery.getPercentage();
-    int low = battery.isLow() ? 1 : 0;
-    int full = battery.isFull() ? 1 : 0;
     int state = static_cast<int>(battery.getChargeState());
     int wifi = WIFI_DISABLED;
     if (WiFi.getMode() != WIFI_MODE_NULL)
@@ -448,7 +446,7 @@ void Receiver::sendStatus()
             wifi = WIFI_ERROR;
         }
     }
-    sprintf(txpacket, "S:%d:%d:%d:%d:%d:%d:%d:%d:%d:%d", txPower, mLastRssi, mLastSnr, mRelayState ? 1 : 0, mPulseMode ? 1 : 0, b, low, full, state, wifi);
+    sprintf(txpacket, "S:%d:%d:%d:%d:%d:%d:%d:%d", txPower, mLastRssi, mLastSnr, mRelayState ? 1 : 0, mPulseMode ? 1 : 0, b, state, wifi);
 
     pendingDailyStats = true;
     send(txpacket, strlen(txpacket));

--- a/heltec-controller-receiver/include/controller.h
+++ b/heltec-controller-receiver/include/controller.h
@@ -70,7 +70,7 @@ private:
 
     void publishControllerStatus();
     void publishReceiverStatus(int power, int rssi, int snr, bool relay, bool pulse, int battery,
-                               bool low, bool full, int chargeState, int wifi);
+                               int chargeState, int wifi);
     void publishReceiverDailyStats(const struct DailyStats &stats);
 
     void setSendStatusFrequency(unsigned int freq);

--- a/heltec-controller-receiver/src/controller.cpp
+++ b/heltec-controller-receiver/src/controller.cpp
@@ -153,7 +153,7 @@ void Controller::publishControllerStatus() {
 }
 
 void Controller::publishReceiverStatus(int power, int rssi, int snr, bool relay, bool pulse, int battery,
-                                       bool low, bool full, int chargeState, int wifi) {
+                                       int chargeState, int wifi) {
     char payload[200];
     const char *charge;
     switch (chargeState) {
@@ -171,12 +171,10 @@ void Controller::publishReceiverStatus(int power, int rssi, int snr, bool relay,
         default: wifiState = "UNKNOWN"; break;
     }
     snprintf(payload, sizeof(payload),
-             "{\"power\":%d,\"rssi\":%d,\"snr\":%d,\"state\":\"%s\",\"mode\":\"%s\",\"battery\":%d,\"low\":%s,\"full\":%s,\"charge\":\"%s\",\"wifi\":\"%s\"}",
+             "{\"power\":%d,\"rssi\":%d,\"snr\":%d,\"state\":\"%s\",\"mode\":\"%s\",\"battery\":%d,\"charge\":\"%s\",\"wifi\":\"%s\"}",
              power, rssi, snr,
              relay ? "ON" : "OFF",
              pulse ? "pulse" : "normal", battery,
-             low ? "true" : "false",
-             full ? "true" : "false",
              charge, wifiState);
     mqttClient.publish("pump_station/status/receiver", payload, true);
 }
@@ -728,18 +726,16 @@ void Controller::processReceived(char *rxpacket)
         }
         else if(strlen(strings[0]) == 1 && strings[0][0] == 'S')
         {
-            if(index >= 11) {
+            if(index >= 9) {
                 int power = atoi(strings[1]);
                 int rssi = atoi(strings[2]);
                 int snr = atoi(strings[3]);
                 bool state = atoi(strings[4]);
                 bool pulse = atoi(strings[5]);
                 int battery = atoi(strings[6]);
-                bool low = atoi(strings[7]);
-                bool full = atoi(strings[8]);
-                int cstate = atoi(strings[9]);
-                int wifi = atoi(strings[10]);
-                publishReceiverStatus(power, rssi, snr, state, pulse, battery, low, full, cstate, wifi);
+                int cstate = atoi(strings[7]);
+                int wifi = atoi(strings[8]);
+                publishReceiverStatus(power, rssi, snr, state, pulse, battery, cstate, wifi);
             } else if(index >= 8) {
                 int power = atoi(strings[1]);
                 int rssi = atoi(strings[2]);
@@ -748,7 +744,7 @@ void Controller::processReceived(char *rxpacket)
                 bool pulse = atoi(strings[5]);
                 int battery = atoi(strings[6]);
                 int wifi = atoi(strings[7]);
-                publishReceiverStatus(power, rssi, snr, state, pulse, battery, false, false, -1, wifi);
+                publishReceiverStatus(power, rssi, snr, state, pulse, battery, -1, wifi);
             } else if(index >= 7) {
                 int power = atoi(strings[1]);
                 int rssi = atoi(strings[2]);
@@ -756,7 +752,7 @@ void Controller::processReceived(char *rxpacket)
                 bool state = atoi(strings[4]);
                 bool pulse = atoi(strings[5]);
                 int battery = atoi(strings[6]);
-                publishReceiverStatus(power, rssi, snr, state, pulse, battery, false, false, -1, WIFI_DISABLED);
+                publishReceiverStatus(power, rssi, snr, state, pulse, battery, -1, WIFI_DISABLED);
             }
         }
         else if(strlen(strings[0]) == 1 && strings[0][0] == 'D')


### PR DESCRIPTION
## Summary
- drop `low` and `full` battery flags from LoRa status packet and MQTT JSON
- adjust controller parsing and documentation accordingly

## Testing
- `pio run` *(esp32-c3-receiver; fails: config-private.h: No such file or directory)*
- `pio run` *(heltec-controller-receiver; fails: WIFI_SSID was not declared in this scope)*

------
https://chatgpt.com/codex/tasks/task_e_688dbfeeb2f8832ba5e4caff0fbb0806