### PR TITLE
Fix receiver status parsing and wifi detection

### DIFF
--- a/esp32-c3-receiver/src/receiver.cpp
+++ b/esp32-c3-receiver/src/receiver.cpp
@@ -430,21 +430,18 @@ void Receiver::sendStatus()
     int b = (int) battery.getPercentage();
     int state = static_cast<int>(battery.getChargeState());
     int wifi = WIFI_DISABLED;
-    if (WiFi.getMode() != WIFI_MODE_NULL)
+    wl_status_t st = WiFi.status();
+    if (st == WL_CONNECTED)
     {
-        wl_status_t st = WiFi.status();
-        if (st == WL_CONNECTED)
-        {
-            wifi = WIFI_CONNECTED;
-        }
-        else if (st == WL_DISCONNECTED || st == WL_IDLE_STATUS)
-        {
-            wifi = WIFI_CONNECTING;
-        }
-        else
-        {
-            wifi = WIFI_ERROR;
-        }
+        wifi = WIFI_CONNECTED;
+    }
+    else if (st == WL_DISCONNECTED || st == WL_IDLE_STATUS)
+    {
+        wifi = WIFI_CONNECTING;
+    }
+    else if (st != WL_NO_SHIELD)
+    {
+        wifi = WIFI_ERROR;
     }
     sprintf(txpacket, "S:%d:%d:%d:%d:%d:%d:%d:%d", txPower, mLastRssi, mLastSnr, mRelayState ? 1 : 0, mPulseMode ? 1 : 0, b, state, wifi);
 

--- a/heltec-controller-receiver/src/controller.cpp
+++ b/heltec-controller-receiver/src/controller.cpp
@@ -726,33 +726,23 @@ void Controller::processReceived(char *rxpacket)
         }
         else if(strlen(strings[0]) == 1 && strings[0][0] == 'S')
         {
-            if(index >= 9) {
+            if(index >= 7) {
                 int power = atoi(strings[1]);
                 int rssi = atoi(strings[2]);
                 int snr = atoi(strings[3]);
                 bool state = atoi(strings[4]);
                 bool pulse = atoi(strings[5]);
                 int battery = atoi(strings[6]);
-                int cstate = atoi(strings[7]);
-                int wifi = atoi(strings[8]);
+
+                int cstate = -1;
+                int wifi = WIFI_DISABLED;
+                if(index >= 9) {
+                    cstate = atoi(strings[7]);
+                    wifi = atoi(strings[8]);
+                } else if(index >= 8) {
+                    wifi = atoi(strings[7]);
+                }
                 publishReceiverStatus(power, rssi, snr, state, pulse, battery, cstate, wifi);
-            } else if(index >= 8) {
-                int power = atoi(strings[1]);
-                int rssi = atoi(strings[2]);
-                int snr = atoi(strings[3]);
-                bool state = atoi(strings[4]);
-                bool pulse = atoi(strings[5]);
-                int battery = atoi(strings[6]);
-                int wifi = atoi(strings[7]);
-                publishReceiverStatus(power, rssi, snr, state, pulse, battery, -1, wifi);
-            } else if(index >= 7) {
-                int power = atoi(strings[1]);
-                int rssi = atoi(strings[2]);
-                int snr = atoi(strings[3]);
-                bool state = atoi(strings[4]);
-                bool pulse = atoi(strings[5]);
-                int battery = atoi(strings[6]);
-                publishReceiverStatus(power, rssi, snr, state, pulse, battery, -1, WIFI_DISABLED);
             }
         }
         else if(strlen(strings[0]) == 1 && strings[0][0] == 'D')


### PR DESCRIPTION
## Summary
- Use WiFi.status() to correctly map wifi state before reporting receiver status
- Simplify controller's status parsing to always forward charge and wifi fields when present

## Testing
- `pio test` *(esp32-c3-receiver)*
- `pio test` *(heltec-controller-receiver)*

------
https://chatgpt.com/codex/tasks/task_e_688dc465e048832baa2de6d4901d51e3