### PR TITLE
Add Arduino OTA support to Heltec project

### DIFF
--- a/heltec-controller-receiver/src/controller.cpp
+++ b/heltec-controller-receiver/src/controller.cpp
@@ -4,6 +4,7 @@
 #include <SPI.h>
 #include "LoRaWan_APP.h"
 #include "Arduino.h"
+#include <ArduinoOTA.h>
 
 #include "config.h"
 #include "display.h"
@@ -392,6 +393,8 @@ void Controller::setup() {
         delay(500);
     }
     Serial.println("Init Wifi - complete");
+    ArduinoOTA.setHostname("heltec-pump-controller");
+    ArduinoOTA.begin();
 
     //
     // Setup radio.
@@ -533,6 +536,7 @@ void Controller::pulseRelay(unsigned int onTime)
 
 
 void Controller::loop() {
+    ArduinoOTA.handle();
     if(autoOffTime && millis() > autoOffTime) {
         autoOffTime = 0;
         heartbeatEnabled = false;

--- a/heltec-controller-receiver/src/receiver.cpp
+++ b/heltec-controller-receiver/src/receiver.cpp
@@ -3,6 +3,7 @@
 #include <SPI.h>
 #include "LoRaWan_APP.h"
 #include "Arduino.h"
+#include <ArduinoOTA.h>
 
 #include "config.h"
 #include "display.h"
@@ -117,6 +118,8 @@ void Receiver::setup()
             delay(500);
         }
         Serial.println("Init Wifi - complete");
+        ArduinoOTA.setHostname("heltec-pump-receiver");
+        ArduinoOTA.begin();
     }
     Mcu.begin();
 
@@ -228,6 +231,10 @@ unsigned long lastScreenUpdate = 0;
 
 void Receiver::loop()
 {
+    if (mWifiEnabled && WiFi.status() == WL_CONNECTED)
+    {
+        ArduinoOTA.handle();
+    }
     if(mRelayState && offTime && millis() > offTime) {
         setRelayState(false);
     }


### PR DESCRIPTION
## Summary
- enable ArduinoOTA in Heltec controller with hostname `heltec-pump-controller`
- enable ArduinoOTA in Heltec receiver with hostname `heltec-pump-receiver`

## Testing
- `cd heltec-controller-receiver && pio run`

------
https://chatgpt.com/codex/tasks/task_e_688ddd652648832b82a6404d91ef8887