### PR TITLE
Align Heltec receiver OTA protocol with ESP32-C3

### DIFF
--- a/heltec-controller-receiver/include/receiver.h
+++ b/heltec-controller-receiver/include/receiver.h
@@ -30,6 +30,8 @@ class Receiver : public Device
     void updateDisplay();
     void setIdle();
     bool mWifiEnabled=false;
+    void connectWifi(const char *ssid, const char *pass);
+    void disableWifi();
     private:
     Display &mDisplay;
     Battery &mBattery;
@@ -49,6 +51,7 @@ class Receiver : public Device
     int txPower = TX_OUTPUT_POWER;
     unsigned int statusSendFreqSec = DEFAULT_STATUS_SEND_FREQ_SEC;
     unsigned long lastStatusSend = 0;
+    bool otaEnabled = false;
     void sendAck(char *rxpacket);
     void setRelayState(bool newRelayState);
     void processReceived(char *rxpacket);


### PR DESCRIPTION
## Summary
- add Wi-Fi control hooks and OTA state tracking
- include battery charge state and Wi-Fi status in status packets
- support Wi-Fi connect/disable commands over the air

## Testing
- `pio run` *(fails: 'WIFI_SSID' not declared)*

------
https://chatgpt.com/codex/tasks/task_e_688de08b0314832ba0d571b390a98112