### PR TITLE
Send status updates on change for ESP32 C3 receiver

### DIFF
--- a/esp32-c3-receiver/include/device-config.h
+++ b/esp32-c3-receiver/include/device-config.h
@@ -40,7 +40,7 @@
 #define DEFAULT_ON_TIME_SEC                         300
 
 // Default frequency in seconds to send a status update
-#define DEFAULT_STATUS_SEND_FREQ_SEC                60
+#define DEFAULT_STATUS_SEND_FREQ_SEC                300
 
 // Milliseconds to wait without receiving any packets from the receiver
 // before marking the relay state as unknown.

--- a/esp32-c3-receiver/include/receiver.h
+++ b/esp32-c3-receiver/include/receiver.h
@@ -4,6 +4,7 @@
 #include "device.h"
 #include "device-config.h"
 #include "settings.h"
+#include "BatteryMonitor.h"
 
 
 class Receiver : public Device
@@ -29,6 +30,8 @@ class Receiver : public Device
     void sendHello();
     void updateDisplay();
     void setIdle();
+    int getWifiState();
+    void updateStatusCache();
     private:
     
     String mLastMessage;
@@ -49,6 +52,9 @@ class Receiver : public Device
     unsigned long lastStatusSend = 0;
     bool pendingDailyStats = false;
     bool mIsTransmitting = false;
+    int lastBatteryPct = -1;
+    ChargeState lastChargeState = STABLE;
+    int lastWifiState = WIFI_DISABLED;
     void sendAck(char *rxpacket);
     void setRelayState(bool newRelayState);
     void processReceived(char *rxpacket);


### PR DESCRIPTION
## Summary
- trigger status message when battery percentage, charging state, or WiFi state change
- cache last known status values and add helper to derive WiFi state
- increase default periodic status interval to 5 minutes

## Testing
- `pio run`

------
https://chatgpt.com/codex/tasks/task_e_688de9da364c832b9f3d7edf9473c635