### PR TITLE
Reduce battery status spam

### DIFF
--- a/esp32-c3-receiver/include/device-config.h
+++ b/esp32-c3-receiver/include/device-config.h
@@ -42,6 +42,10 @@
 // Default frequency in seconds to send a status update
 #define DEFAULT_STATUS_SEND_FREQ_SEC                300
 
+// Minimum percent change in battery level before sending an immediate status
+// update. Smaller fluctuations are ignored to reduce chatter.
+#define BATTERY_PERCENT_CHANGE_THRESHOLD            2
+
 // Milliseconds to wait without receiving any packets from the receiver
 // before marking the relay state as unknown.
 #define COMMUNICATION_TIMEOUT_MS                    60000

--- a/esp32-c3-receiver/src/receiver.cpp
+++ b/esp32-c3-receiver/src/receiver.cpp
@@ -498,7 +498,10 @@ void Receiver::loop()
         int b = (int)battery.getPercentage();
         ChargeState cs = battery.getChargeState();
         int wifi = getWifiState();
-        if (b != lastBatteryPct || cs != lastChargeState || wifi != lastWifiState)
+        // Only trigger an immediate status send if battery percent changed
+        // significantly to avoid oscillations causing message spam.
+        if (abs(b - lastBatteryPct) >= BATTERY_PERCENT_CHANGE_THRESHOLD ||
+            cs != lastChargeState || wifi != lastWifiState)
         {
             if (lora_idle)
             {


### PR DESCRIPTION
## Summary
- only send immediate status when battery percentage changes by a meaningful amount
- expose `BATTERY_PERCENT_CHANGE_THRESHOLD` constant

## Testing
- `pio run -e lolin_c3_mini`
- `pio test -e lolin_c3_mini` *(fails: nothing to build)*

------
https://chatgpt.com/codex/tasks/task_e_688df7594a90832b91927e8b81346308