### PR TITLE
Smooth battery percentage to reduce status spam

### DIFF
--- a/esp32-c3-receiver/include/BatteryMonitor.h
+++ b/esp32-c3-receiver/include/BatteryMonitor.h
@@ -29,6 +29,7 @@ public:
     void setVoltageRange(float vEmpty, float vFull);
     float getPercentage() const;
     float getPercentageCurve() const;
+    float getFilteredPercentage() const;
 
     // Charge state
     ChargeState getChargeState() const;
@@ -114,6 +115,10 @@ private:
     unsigned long _lastDebugPrint;
     float _lastRawAvg;
     float _calibrationFactor;
+    float _filteredSOC;
+    bool _filteredSOCInitialized;
+    float _alphaDown;
+    float _alphaUp;
 };
 
 extern BatteryMonitor battery;

--- a/esp32-c3-receiver/src/receiver.cpp
+++ b/esp32-c3-receiver/src/receiver.cpp
@@ -463,7 +463,7 @@ int Receiver::getWifiState()
 
 void Receiver::updateStatusCache()
 {
-    lastBatteryPct = (int)battery.getPercentage();
+    lastBatteryPct = (int)battery.getFilteredPercentage();
     lastChargeState = battery.getChargeState();
     lastWifiState = getWifiState();
 }
@@ -495,7 +495,7 @@ void Receiver::loop()
 
     if (millis() - lastServiceUpdate > serviceUpdateFrequency)
     {
-        int b = (int)battery.getPercentage();
+        int b = (int)battery.getFilteredPercentage();
         ChargeState cs = battery.getChargeState();
         int wifi = getWifiState();
         // Only trigger an immediate status send if battery percent changed


### PR DESCRIPTION
## Summary
- Apply asymmetric smoothing to battery percentage so discharge is reported slowly and charging updates quickly
- Track filtered state-of-charge and expose `getFilteredPercentage()`
- Use smoothed percentage in receiver to limit status update churn

## Testing
- `pio run` *(fails: src/receiver.cpp:7:10: fatal error: config-private.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688dfbc7aa80832b81f2a2876a86fb0e