### PR TITLE
Remove stable battery state and simplify charge logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ It exposes a `switch` entity for basic on/off control and `number` entities name
 It also publishes `sensor` entities `Controller Status` and `Receiver Status`
 which report the JSON data sent to `pump_station/status/controller` and
 `pump_station/status/receiver`. The receiver status now includes a battery
-percentage and a `charge` state of `CHARGING`, `DISCHARGING` or `STABLE`.
+percentage and a `charge` state of `CHARGING` or `DISCHARGING`.
 The controller enforces a minimum transmit power defined by `MIN_TX_OUTPUT_POWER`.
 
 On boot the controller sends a `STATUS` request to the receiver. The receiver

--- a/esp32-c3-receiver/include/BatteryMonitor.h
+++ b/esp32-c3-receiver/include/BatteryMonitor.h
@@ -5,8 +5,7 @@
 
 enum ChargeState {
     CHARGING,
-    DISCHARGING,
-    STABLE
+    DISCHARGING
 };
 
 class BatteryMonitor {
@@ -87,7 +86,6 @@ private:
     float _vFull;
 
     mutable ChargeState _chargeState;
-    ChargeState _pendingState;
     int _stateStreak;
     float _emaShort;
     float _emaLong;

--- a/esp32-c3-receiver/include/receiver.h
+++ b/esp32-c3-receiver/include/receiver.h
@@ -53,7 +53,7 @@ class Receiver : public Device
     bool pendingDailyStats = false;
     bool mIsTransmitting = false;
     int lastBatteryPct = -1;
-    ChargeState lastChargeState = STABLE;
+    ChargeState lastChargeState = DISCHARGING;
     int lastWifiState = WIFI_DISABLED;
     void sendAck(char *rxpacket);
     void setRelayState(bool newRelayState);

--- a/heltec-controller-receiver/src/controller.cpp
+++ b/heltec-controller-receiver/src/controller.cpp
@@ -160,7 +160,6 @@ void Controller::publishReceiverStatus(int power, int rssi, int snr, bool relay,
     switch (chargeState) {
         case 0: charge = "CHARGING"; break;
         case 1: charge = "DISCHARGING"; break;
-        case 2: charge = "STABLE"; break;
         default: charge = "UNKNOWN"; break;
     }
     const char *wifiState;


### PR DESCRIPTION
## Summary
- drop unused `STABLE` battery state and treat values as charging or discharging only
- streamline charge state transition logic for BatteryMonitor
- adjust controller mapping and documentation for two-state battery model

## Testing
- `pio run` *(fails: command not found)*
- `pio run` in `heltec-controller-receiver` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_688dff84f268832ba06336768262f871