### PR TITLE
Ensure disabled WiFi stays disabled

### DIFF
--- a/esp32-c3-receiver/src/receiver.cpp
+++ b/esp32-c3-receiver/src/receiver.cpp
@@ -444,21 +444,22 @@ void Receiver::sendStatus()
 
 int Receiver::getWifiState()
 {
-    int wifi = WIFI_DISABLED;
+    // If the WiFi subsystem is not started, report disabled regardless of status
+    if (WiFi.getMode() == WIFI_MODE_NULL) {
+        return WIFI_DISABLED;
+    }
+
     wl_status_t st = WiFi.status();
-    if (st == WL_CONNECTED)
-    {
-        wifi = WIFI_CONNECTED;
+    if (st == WL_CONNECTED) {
+        return WIFI_CONNECTED;
     }
-    else if (st == WL_DISCONNECTED || st == WL_IDLE_STATUS)
-    {
-        wifi = WIFI_CONNECTING;
+    if (st == WL_DISCONNECTED || st == WL_IDLE_STATUS) {
+        return WIFI_CONNECTING;
     }
-    else if (st != WL_NO_SHIELD)
-    {
-        wifi = WIFI_ERROR;
+    if (st != WL_NO_SHIELD) {
+        return WIFI_ERROR;
     }
-    return wifi;
+    return WIFI_DISABLED;
 }
 
 void Receiver::updateStatusCache()


### PR DESCRIPTION
## Summary
- avoid reporting WiFi as connecting when the radio is off on the ESP32-C3 receiver

## Testing
- `pio run -e lolin_c3_mini` *(fails: config-private.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688e04eb4860832bbc98728d5311e1db