### PR TITLE
refactor: streamline lora messaging

### DIFF
--- a/esp32-c3-receiver/include/receiver.h
+++ b/esp32-c3-receiver/include/receiver.h
@@ -44,9 +44,7 @@ class Receiver : public Device
     // Duration to keep the relay on. This value is provided by the
     // controller in the ON message.
     unsigned int onTimeSec = 0;
-    int acksRemaining;
-    uint16_t ackStateId;
-    bool ackConfirmed;
+    uint16_t lastCommandId = 0;
     int txPower = TX_OUTPUT_POWER;
     unsigned int statusSendFreqSec = DEFAULT_STATUS_SEND_FREQ_SEC;
     unsigned long lastStatusSend = 0;
@@ -55,7 +53,7 @@ class Receiver : public Device
     int lastBatteryPct = -1;
     ChargeState lastChargeState = DISCHARGING;
     int lastWifiState = WIFI_DISABLED;
-    void sendAck(char *rxpacket);
+    void sendAck(uint16_t id, const char *status);
     void setRelayState(bool newRelayState);
     void processReceived(char *rxpacket);
     void send(char *packet, size_t len);

--- a/heltec-controller-receiver/include/receiver.h
+++ b/heltec-controller-receiver/include/receiver.h
@@ -45,14 +45,12 @@ class Receiver : public Device
     // Duration to keep the relay on. This value is provided by the
     // controller in the ON message.
     unsigned int onTimeSec = 0;
-    int acksRemaining;
-    uint16_t ackStateId;
-    bool ackConfirmed;
+    uint16_t lastCommandId = 0;
     int txPower = TX_OUTPUT_POWER;
     unsigned int statusSendFreqSec = DEFAULT_STATUS_SEND_FREQ_SEC;
     unsigned long lastStatusSend = 0;
     bool otaEnabled = false;
-    void sendAck(char *rxpacket);
+    void sendAck(uint16_t id, const char *status);
     void setRelayState(bool newRelayState);
     void processReceived(char *rxpacket);
 

--- a/heltec-controller-receiver/src/receiver.cpp
+++ b/heltec-controller-receiver/src/receiver.cpp
@@ -21,7 +21,6 @@ Receiver *instance;
 
 char txpacket[BUFFER_SIZE];
 char rxpacket[BUFFER_SIZE];
-char ackpacket[BUFFER_SIZE];
 
 double txNumber;
 
@@ -46,9 +45,6 @@ Receiver::Receiver(Display &display, Battery &battery, bool enableWifi) : mDispl
     mLastSnr = 0;
     mRelayState = false;
     mPulseMode = false;
-    acksRemaining = 0;
-    ackStateId = 0;
-    ackConfirmed = true;
     lastStatusSend = 0;
     otaEnabled = false;
 }
@@ -68,21 +64,16 @@ void Receiver::updateDisplay()
 
     y+=step;
     mDisplay.display.setCursor(x, y);
-    mDisplay.display.printf("Ack: %s", ackConfirmed ? "OK" : "WAIT");
-    
-    y+=step;
-    mDisplay.display.setCursor(x, y);
+    unsigned long remaining = 0;
+    if(mRelayState && offTime > millis()) {
+        remaining = (offTime - millis()) / 1000;
+    }
+    mDisplay.display.setCursor(x, y + step);
     if(mRelayState) {
-        unsigned long remaining = 0;
-        if(offTime > millis()) {
-            remaining = (offTime - millis()) / 1000;
-        }
         mDisplay.display.printf("Time: %lus", remaining);
-    } else {
-        mDisplay.display.printf("Pend Acks: %d", acksRemaining);
     }
 
-    y+=step;
+    y += step * 2;
     mDisplay.display.setCursor(x, y);
     mDisplay.display.printf("PW:%d RS:%d SR:%d", txPower, mLastRssi, mLastSnr);
 
@@ -233,13 +224,6 @@ void Receiver::loop()
     {
         updateDisplay();
 
-        if (!ackConfirmed && acksRemaining)
-        {
-            --acksRemaining;
-            delay(100);
-            sendAck(ackpacket);
-        }
-
         lastScreenUpdate = millis();
     }
 
@@ -255,18 +239,12 @@ void Receiver::loop()
     }
 }
 
-void Receiver::sendAck(char *packet)
+void Receiver::sendAck(uint16_t id, const char *status)
 {
-    //
-    // Mark the packet as from the receiver.
-    //
-    packet[0] = 'R';
-
-    Serial.printf("Sending ack \"%s\", length %d\r\n", packet, strlen(packet));
-
+    snprintf(txpacket, sizeof(txpacket), "A:%u:%s", id, status);
+    Serial.printf("Sending ack \"%s\", length %d\r\n", txpacket, strlen(txpacket));
     lora_idle = false;
-    Radio.Send((uint8_t *)packet, strlen(packet)); // send the package out
-
+    Radio.Send((uint8_t *)txpacket, strlen(txpacket));
     Serial.println("ack packet sent.");
 }
 
@@ -308,9 +286,6 @@ void Receiver::processReceived(char *rxpacket)
     char *ptr = NULL;
     int index = 0;
 
-    ackpacket[0] = 0; 
-    strcpy(ackpacket, rxpacket);
-
     ptr = strtok(rxpacket, ":;"); // takes a list of delimiters
     while (ptr != NULL)
     {
@@ -318,37 +293,34 @@ void Receiver::processReceived(char *rxpacket)
         index++;
         ptr = strtok(NULL, ":;"); // takes a list of delimiters
     }
+    if (index >= 3 && strlen(strings[0]) == 1 && strings[0][0] == 'C')
+    {
+        uint16_t stateId = atoi(strings[1]);
+        const char *resp = NULL;
+        bool duplicate = stateId <= lastCommandId;
 
-    if (index >= 2 && strlen(strings[0]) == 1 && strings[0][0] == 'A')
-    {
-        uint16_t stateId = atoi(strings[1]);
-        if(stateId == ackStateId)
-        {
-            ackConfirmed = true;
-            acksRemaining = 0;
-        }
-    }
-    else if (index >= 3 && strlen(strings[0]) == 1 && strings[0][0] == 'C')
-    {
-        uint16_t stateId = atoi(strings[1]);
         if(strcasecmp(strings[2], "status") == 0) {
             sendStatus();
-            return;
+            resp = "status";
         } else if(strcasecmp(strings[2], "freq") == 0 && index >= 4) {
             int freq = atoi(strings[3]);
-            setSendStatusFrequency(freq);
-            return;
+            if(!duplicate) setSendStatusFrequency(freq);
+            resp = "freq";
         } else if(strcasecmp(strings[2], "pwr") == 0 && index >= 4) {
             int power = atoi(strings[3]);
-            setTxPower(power);
+            if(!duplicate) setTxPower(power);
+            resp = "pwr";
         } else if(strcasecmp(strings[2], "wifi") == 0) {
-            if (index >= 4 && strcasecmp(strings[3], "off") == 0) {
-                disableWifi();
-            } else {
-                const char *ssid = (index >= 4) ? strings[3] : WIFI_SSID;
-                const char *pass = (index >= 5) ? strings[4] : WIFI_PASS;
-                connectWifi(ssid, pass);
+            if(!duplicate) {
+                if (index >= 4 && strcasecmp(strings[3], "off") == 0) {
+                    disableWifi();
+                } else {
+                    const char *ssid = (index >= 4) ? strings[3] : WIFI_SSID;
+                    const char *pass = (index >= 5) ? strings[4] : WIFI_PASS;
+                    connectWifi(ssid, pass);
+                }
             }
+            resp = "wifi";
         } else {
             bool newRelayState = false;
             if(strcasecmp(strings[2], "on") == 0 || strcasecmp(strings[2], "pulse") == 0) {
@@ -360,12 +332,12 @@ void Receiver::processReceived(char *rxpacket)
                 onTimeSec = 0;
             }
             mPulseMode = strcasecmp(strings[2], "pulse") == 0;
-            setRelayState(newRelayState);
+            if(!duplicate) setRelayState(newRelayState);
+            resp = newRelayState ? (mPulseMode ? "pulse" : "on") : "off";
         }
+        if(!duplicate) lastCommandId = stateId;
         delay(200);
-        ackStateId = stateId;
-        ackConfirmed = false;
-        acksRemaining = 4;
+        sendAck(stateId, resp ? resp : "ok");
     }
 }
 


### PR DESCRIPTION
## Summary
- introduce generalized outgoing message queue with coalescing and retry logic for controller
- simplify acknowledgement flow; receivers track last command id and respond once
- mirror streamlined ack handling for esp32-c3 receiver

## Testing
- `pio run -e controller` *(fails: 'MQTT_USER' not declared)*
- `pio run -e lolin_c3_mini` *(fails: missing `config-private.h`)*

------
https://chatgpt.com/codex/tasks/task_e_688e10450488832b9b176e45179e9a39