### PR TITLE
Ensure relay stays on by refreshing ON command before timeout

### DIFF
--- a/heltec-controller-receiver/include/controller.h
+++ b/heltec-controller-receiver/include/controller.h
@@ -89,6 +89,9 @@ private:
     // Timestamp of the last packet received from the receiver
     unsigned long lastContactTime = 0;
 
+    // Next time to refresh the ON command before receiver timeout
+    unsigned long nextRelayRefresh = 0;
+
     // Outgoing message queue
     struct OutgoingMessage {
         String type;


### PR DESCRIPTION
## Summary
- add scheduler for periodic ON command refresh to maintain pump state
- resend ON command halfway before receiver timeout

## Testing
- `pio test -e controller` *(fails: Nothing to build. Please put your test suites to the '/workspace/esp32-sx1262-lora-relay/heltec-controller-receiver/test' folder)*
- `pio run -e controller` *(fails: 'WIFI_SSID' was not declared in this scope)*

------
https://chatgpt.com/codex/tasks/task_e_688e1de87ff8832b8afaff3fb180d63e