### PR TITLE
feat: report battery with fractional percent

### DIFF
--- a/esp32-c3-receiver/include/controller.h
+++ b/esp32-c3-receiver/include/controller.h
@@ -66,7 +66,7 @@ private:
     void pulseRelay(unsigned int onTime);
 
     void publishControllerStatus();
-    void publishReceiverStatus(int power, int rssi, int snr, bool relay, bool pulse, int battery,
+    void publishReceiverStatus(int power, int rssi, int snr, bool relay, bool pulse, float battery,
                                int chargeState, int wifi);
     void publishReceiverDailyStats(const struct DailyStats &stats);
 

--- a/esp32-c3-receiver/include/receiver.h
+++ b/esp32-c3-receiver/include/receiver.h
@@ -50,7 +50,7 @@ class Receiver : public Device
     unsigned long lastStatusSend = 0;
     bool pendingDailyStats = false;
     bool mIsTransmitting = false;
-    int lastBatteryPct = -1;
+    float lastBatteryPct = -1;
     ChargeState lastChargeState = DISCHARGING;
     int lastWifiState = WIFI_DISABLED;
     void sendAck(uint16_t id, const char *status);

--- a/esp32-c3-receiver/src/controller.cpp
+++ b/esp32-c3-receiver/src/controller.cpp
@@ -115,16 +115,16 @@ void Controller::publishState() {
 
 void Controller::publishControllerStatus() {
     char payload[128];
-    int batt = (int)battery.getFilteredPercentage();
+    float batt = battery.getFilteredPercentage();
     snprintf(payload, sizeof(payload),
-             "{\"power\":%d,\"rssi\":%d,\"snr\":%d,\"state\":\"%s\",\"mode\":\"%s\",\"battery\":%d}",
+             "{\"power\":%d,\"rssi\":%d,\"snr\":%d,\"state\":\"%s\",\"mode\":\"%s\",\"battery\":%.1f}",
              txPower, mLastRssi, mLastSnr,
              relayStateToString(relayState).c_str(),
              pulseMode ? "pulse" : "normal", batt);
     mqttClient.publish("pump_station/status/controller", payload, true);
 }
 
-void Controller::publishReceiverStatus(int power, int rssi, int snr, bool relay, bool pulse, int batteryPct,
+void Controller::publishReceiverStatus(int power, int rssi, int snr, bool relay, bool pulse, float batteryPct,
                                        int chargeState, int wifi) {
     char payload[200];
     const char *charge;
@@ -142,7 +142,7 @@ void Controller::publishReceiverStatus(int power, int rssi, int snr, bool relay,
         default: wifiState = "UNKNOWN"; break;
     }
     snprintf(payload, sizeof(payload),
-             "{\"power\":%d,\"rssi\":%d,\"snr\":%d,\"state\":\"%s\",\"mode\":\"%s\",\"battery\":%d,\"charge\":\"%s\",\"wifi\":\"%s\"}",
+             "{\"power\":%d,\"rssi\":%d,\"snr\":%d,\"state\":\"%s\",\"mode\":\"%s\",\"battery\":%.1f,\"charge\":\"%s\",\"wifi\":\"%s\"}",
              power, rssi, snr,
              relay ? "ON" : "OFF",
              pulse ? "pulse" : "normal", batteryPct,
@@ -476,7 +476,7 @@ void Controller::processReceived(char *rxpacket) {
                 int snr = atoi(strings[3]);
                 bool state = atoi(strings[4]);
                 bool pulse = atoi(strings[5]);
-                int batt = atoi(strings[6]);
+                float batt = atof(strings[6]);
                 int cstate = -1;
                 int wifi = WIFI_DISABLED;
                 if(index >= 9) {


### PR DESCRIPTION
## Summary
- send controller battery and receiver battery values with 0.1% precision
- propagate fractional battery percentages through LoRa parsing and MQTT publishing
- handle battery change thresholds using floating-point math

## Testing
- `pio run` *(fails: config-private.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688ecdd3069c832bb5b51b94bfdc1502