### PR TITLE
feat: show battery with decimal precision

### DIFF
--- a/heltec-controller-receiver/include/battery.h
+++ b/heltec-controller-receiver/include/battery.h
@@ -8,7 +8,7 @@ class Battery {
 public:
     Battery();
     void setup();
-    int getPercentage();
+    float getPercentage();
     float getVoltage();
     bool isCharging();
 

--- a/heltec-controller-receiver/include/controller.h
+++ b/heltec-controller-receiver/include/controller.h
@@ -72,7 +72,7 @@ private:
     void pulseRelay(unsigned int onTime);
 
     void publishControllerStatus();
-    void publishReceiverStatus(int power, int rssi, int snr, bool relay, bool pulse, int battery,
+    void publishReceiverStatus(int power, int rssi, int snr, bool relay, bool pulse, float battery,
                                int chargeState, int wifi);
     void publishReceiverDailyStats(const struct DailyStats &stats);
 

--- a/heltec-controller-receiver/src/battery.cpp
+++ b/heltec-controller-receiver/src/battery.cpp
@@ -1,4 +1,5 @@
 #include "battery.h"
+#include <math.h>
 
 #define VBAT_Read 1
 #define ADC_Ctrl 37
@@ -11,22 +12,21 @@ void Battery::setup()
     analogSetAttenuation(ADC_11db);
 }
 
-int Battery::getPercentage()
-{    
-    const float min = 3.0;
-    const float max = 4.2;
+float Battery::getPercentage()
+{
+    const float min = 3.0f;
+    const float max = 4.2f;
 
     readBatteryVoltage();
 
-    // float voltage = getVoltage();
-    int percent = floor(((mVoltage - min) / (max - min)) * 100);
+    float percent = ((mVoltage - min) / (max - min)) * 100.0f;
+    // Round to one decimal place
+    percent = roundf(percent * 10.0f) / 10.0f;
 
-    // Serial.printf("RAW BAT: percent: %d%% volts: %.2f\n", percent, mVoltage);
-
-    if (percent < 0)
-        percent = 0;
-    if (percent > 100)
-        percent = 100;
+    if (percent < 0.0f)
+        percent = 0.0f;
+    if (percent > 100.0f)
+        percent = 100.0f;
     return percent;
 }
 

--- a/heltec-controller-receiver/src/controller.cpp
+++ b/heltec-controller-receiver/src/controller.cpp
@@ -130,10 +130,10 @@ void Controller::updateDisplay()
 
     if (mHasBattery)
     {
-        int batt = battery.getPercentage();
+        float batt = battery.getPercentage();
         bool chg = battery.isCharging();
         mDisplay.display.setCursor(10, 58);
-        mDisplay.display.printf("BAT:%d%% %s", batt, chg ? "CHG" : " ");
+        mDisplay.display.printf("BAT:%.1f%% %s", batt, chg ? "CHG" : " ");
     }
     mDisplay.display.display();
 }
@@ -145,16 +145,16 @@ void Controller::publishState() {
 
 void Controller::publishControllerStatus() {
     char payload[128];
-    int batt = battery.getPercentage();
+    float batt = battery.getPercentage();
     snprintf(payload, sizeof(payload),
-             "{\"power\":%d,\"rssi\":%d,\"snr\":%d,\"state\":\"%s\",\"mode\":\"%s\",\"battery\":%d}",
+             "{\"power\":%d,\"rssi\":%d,\"snr\":%d,\"state\":\"%s\",\"mode\":\"%s\",\"battery\":%.1f}",
              txPower, mLastRssi, mLastSnr,
              relayStateToString(relayState).c_str(),
              pulseMode ? "pulse" : "normal", batt);
     mqttClient.publish("pump_station/status/controller", payload, true);
 }
 
-void Controller::publishReceiverStatus(int power, int rssi, int snr, bool relay, bool pulse, int battery,
+void Controller::publishReceiverStatus(int power, int rssi, int snr, bool relay, bool pulse, float battery,
                                        int chargeState, int wifi) {
     char payload[200];
     const char *charge;
@@ -172,7 +172,7 @@ void Controller::publishReceiverStatus(int power, int rssi, int snr, bool relay,
         default: wifiState = "UNKNOWN"; break;
     }
     snprintf(payload, sizeof(payload),
-             "{\"power\":%d,\"rssi\":%d,\"snr\":%d,\"state\":\"%s\",\"mode\":\"%s\",\"battery\":%d,\"charge\":\"%s\",\"wifi\":\"%s\"}",
+             "{\"power\":%d,\"rssi\":%d,\"snr\":%d,\"state\":\"%s\",\"mode\":\"%s\",\"battery\":%.1f,\"charge\":\"%s\",\"wifi\":\"%s\"}",
              power, rssi, snr,
              relay ? "ON" : "OFF",
              pulse ? "pulse" : "normal", battery,
@@ -738,7 +738,7 @@ void Controller::processReceived(char *rxpacket)
                 int snr = atoi(strings[3]);
                 bool state = atoi(strings[4]);
                 bool pulse = atoi(strings[5]);
-                int battery = atoi(strings[6]);
+                float battery = atof(strings[6]);
 
                 int cstate = -1;
                 int wifi = WIFI_DISABLED;

--- a/heltec-controller-receiver/src/receiver.cpp
+++ b/heltec-controller-receiver/src/receiver.cpp
@@ -81,10 +81,10 @@ void Receiver::updateDisplay()
     mDisplay.display.setCursor(x, y);
 
     float voltage = mBattery.getVoltage();
-    int batt = mBattery.getPercentage();
+    float batt = mBattery.getPercentage();
     bool chg = mBattery.isCharging();
 
-    mDisplay.display.printf("BAT: %.2fv  %d%% %s", voltage, batt, chg ? "CHG" : " ");
+    mDisplay.display.printf("BAT: %.2fv  %.1f%% %s", voltage, batt, chg ? "CHG" : " ");
 
     mDisplay.display.display();
 }
@@ -186,7 +186,7 @@ void Receiver::sendHello()
 
 void Receiver::sendStatus()
 {
-    int b = mBattery.getPercentage();
+    float b = mBattery.getPercentage();
     int state = mBattery.isCharging() ? 0 : 1;
     int wifi = WIFI_DISABLED;
     wl_status_t st = WiFi.status();
@@ -202,7 +202,7 @@ void Receiver::sendStatus()
     {
         wifi = WIFI_ERROR;
     }
-    sprintf(txpacket, "S:%d:%d:%d:%d:%d:%d:%d:%d", txPower, mLastRssi, mLastSnr, mRelayState ? 1 : 0, mPulseMode ? 1 : 0, b, state, wifi);
+    sprintf(txpacket, "S:%d:%d:%d:%d:%d:%.1f:%d:%d", txPower, mLastRssi, mLastSnr, mRelayState ? 1 : 0, mPulseMode ? 1 : 0, b, state, wifi);
     Serial.printf("Sending status \"%s\", length %d\r\n", txpacket, strlen(txpacket));
     lora_idle = false;
     Radio.Send((uint8_t *)txpacket, strlen(txpacket));


### PR DESCRIPTION
## Summary
- report battery percentage with 0.1% resolution by rounding Battery::getPercentage
- display and publish controller and receiver battery levels with 1-decimal precision
- parse receiver battery percentage as floating point

## Testing
- `pio run -e controller` *(fails: 'WIFI_SSID' was not declared in this scope)*

------
https://chatgpt.com/codex/tasks/task_e_688edd986234832bb8c1d164cd8fc213