### PR TITLE
Handle command ID wrap-around in receiver duplicate check

### DIFF
--- a/esp32-c3-receiver/src/receiver.cpp
+++ b/esp32-c3-receiver/src/receiver.cpp
@@ -615,7 +615,9 @@ void Receiver::processReceived(char *rxpacket)
     {
         uint16_t stateId = atoi(strings[1]);
         const char *resp = NULL;
-        bool duplicate = stateId <= lastCommandId;
+        // Use signed arithmetic to handle 16-bit wrap-around of state IDs
+        int16_t diff = static_cast<int16_t>(stateId - lastCommandId);
+        bool duplicate = diff <= 0;
 
         if(strcasecmp(strings[2], "status") == 0) {
             sendStatus();

--- a/heltec-controller-receiver/src/receiver.cpp
+++ b/heltec-controller-receiver/src/receiver.cpp
@@ -297,7 +297,9 @@ void Receiver::processReceived(char *rxpacket)
     {
         uint16_t stateId = atoi(strings[1]);
         const char *resp = NULL;
-        bool duplicate = stateId <= lastCommandId;
+        // Use signed arithmetic to handle 16-bit wrap-around of state IDs
+        int16_t diff = static_cast<int16_t>(stateId - lastCommandId);
+        bool duplicate = diff <= 0;
 
         if(strcasecmp(strings[2], "status") == 0) {
             sendStatus();


### PR DESCRIPTION
## Summary
- Avoid misclassifying new commands as duplicates when the 16-bit command ID wraps around
- Use signed arithmetic for duplicate detection in both receiver implementations

## Testing
- `pio run` *(heltec-controller-receiver)* ❌ `MQTT_USER` and other configuration macros missing
- `pio run` *(esp32-c3-receiver)* ❌ `config-private.h` missing


------
https://chatgpt.com/codex/tasks/task_e_68905ba7b630832b9ae0a41aecae52b9