### PR TITLE
feat: add sync message for duplicate handling

### DIFF
--- a/esp32-c3-receiver/src/controller.cpp
+++ b/esp32-c3-receiver/src/controller.cpp
@@ -280,6 +280,8 @@ void Controller::setup() {
 
     ensureMqtt();
     lastStatusPublish = millis();
+    sendMessage("SYNC");
+    sendMessage("STATUS");
 }
 
 void Controller::setIdle() {

--- a/esp32-c3-receiver/src/receiver.cpp
+++ b/esp32-c3-receiver/src/receiver.cpp
@@ -618,7 +618,10 @@ void Receiver::processReceived(char *rxpacket)
         int16_t diff = static_cast<int16_t>(stateId - lastCommandId);
         bool duplicate = diff <= 0;
 
-        if(strcasecmp(strings[2], "status") == 0) {
+        if(strcasecmp(strings[2], "sync") == 0) {
+            duplicate = false;
+            resp = "sync";
+        } else if(strcasecmp(strings[2], "status") == 0) {
             sendStatus();
             resp = "status";
         } else if(strcasecmp(strings[2], "freq") == 0 && index >= 4) {

--- a/heltec-controller-receiver/src/controller.cpp
+++ b/heltec-controller-receiver/src/controller.cpp
@@ -432,9 +432,9 @@ void Controller::setup() {
     ensureMqtt();
     sendDiscovery();
     publishState();
+    sendMessage("SYNC");
     {
         char msg[16];
-        ++mStateId;
         sprintf(msg, "FREQ:%u", receiverStatusFreqSec);
         sendMessage(msg);
     }

--- a/heltec-controller-receiver/src/receiver.cpp
+++ b/heltec-controller-receiver/src/receiver.cpp
@@ -301,7 +301,10 @@ void Receiver::processReceived(char *rxpacket)
         int16_t diff = static_cast<int16_t>(stateId - lastCommandId);
         bool duplicate = diff <= 0;
 
-        if(strcasecmp(strings[2], "status") == 0) {
+        if(strcasecmp(strings[2], "sync") == 0) {
+            duplicate = false;
+            resp = "sync";
+        } else if(strcasecmp(strings[2], "status") == 0) {
             sendStatus();
             resp = "status";
         } else if(strcasecmp(strings[2], "freq") == 0 && index >= 4) {


### PR DESCRIPTION
## Summary
- send one-time SYNC command on startup so receiver resets command tracking
- handle SYNC command on receiver to bypass duplicate detection

## Testing
- `pio run` *(fails: 'MQTT_USER' was not declared in this scope)*
- `pio run` *(fails: `config-private.h: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_68993d187b8c832b9b879b4b8e3148bd