### PR TITLE
Remove duplicate message filtering in receivers

### DIFF
--- a/esp32-c3-receiver/include/receiver.h
+++ b/esp32-c3-receiver/include/receiver.h
@@ -44,7 +44,6 @@ class Receiver : public Device
     // Duration to keep the relay on. This value is provided by the
     // controller in the ON message.
     unsigned int onTimeSec = 0;
-    uint16_t lastCommandId = 0;
     int txPower = TX_OUTPUT_POWER;
     unsigned int statusSendFreqSec = DEFAULT_STATUS_SEND_FREQ_SEC;
     unsigned long lastStatusSend = 0;

--- a/esp32-c3-receiver/src/receiver.cpp
+++ b/esp32-c3-receiver/src/receiver.cpp
@@ -614,33 +614,27 @@ void Receiver::processReceived(char *rxpacket)
     {
         uint16_t stateId = atoi(strings[1]);
         const char *resp = NULL;
-        // Use signed arithmetic to handle 16-bit wrap-around of state IDs
-        int16_t diff = static_cast<int16_t>(stateId - lastCommandId);
-        bool duplicate = diff <= 0;
 
         if(strcasecmp(strings[2], "sync") == 0) {
-            duplicate = false;
             resp = "sync";
         } else if(strcasecmp(strings[2], "status") == 0) {
             sendStatus();
             resp = "status";
         } else if(strcasecmp(strings[2], "freq") == 0 && index >= 4) {
             int freq = atoi(strings[3]);
-            if(!duplicate) setSendStatusFrequency(freq);
+            setSendStatusFrequency(freq);
             resp = "freq";
         } else if(strcasecmp(strings[2], "pwr") == 0 && index >= 4) {
             int power = atoi(strings[3]);
-            if(!duplicate) setTxPower(power);
+            setTxPower(power);
             resp = "pwr";
         } else if(strcasecmp(strings[2], "wifi") == 0) {
-            if(!duplicate) {
-                if (index >= 4 && strcasecmp(strings[3], "off") == 0) {
-                    disableWifi();
-                } else {
-                    const char *ssid = (index >= 4) ? strings[3] : WIFI_SSID;
-                    const char *pass = (index >= 5) ? strings[4] : WIFI_PASS;
-                    connectWifi(ssid, pass);
-                }
+            if (index >= 4 && strcasecmp(strings[3], "off") == 0) {
+                disableWifi();
+            } else {
+                const char *ssid = (index >= 4) ? strings[3] : WIFI_SSID;
+                const char *pass = (index >= 5) ? strings[4] : WIFI_PASS;
+                connectWifi(ssid, pass);
             }
             resp = "wifi";
         } else {
@@ -654,10 +648,9 @@ void Receiver::processReceived(char *rxpacket)
                 onTimeSec = 0;
             }
             mPulseMode = strcasecmp(strings[2], "pulse") == 0;
-            if(!duplicate) setRelayState(newRelayState);
+            setRelayState(newRelayState);
             resp = newRelayState ? (mPulseMode ? "pulse" : "on") : "off";
         }
-        if(!duplicate) lastCommandId = stateId;
         delay(200);
         sendAck(stateId, resp ? resp : "ok");
     }

--- a/heltec-controller-receiver/include/receiver.h
+++ b/heltec-controller-receiver/include/receiver.h
@@ -45,7 +45,6 @@ class Receiver : public Device
     // Duration to keep the relay on. This value is provided by the
     // controller in the ON message.
     unsigned int onTimeSec = 0;
-    uint16_t lastCommandId = 0;
     int txPower = TX_OUTPUT_POWER;
     unsigned int statusSendFreqSec = DEFAULT_STATUS_SEND_FREQ_SEC;
     unsigned long lastStatusSend = 0;

--- a/heltec-controller-receiver/src/receiver.cpp
+++ b/heltec-controller-receiver/src/receiver.cpp
@@ -297,33 +297,27 @@ void Receiver::processReceived(char *rxpacket)
     {
         uint16_t stateId = atoi(strings[1]);
         const char *resp = NULL;
-        // Use signed arithmetic to handle 16-bit wrap-around of state IDs
-        int16_t diff = static_cast<int16_t>(stateId - lastCommandId);
-        bool duplicate = diff <= 0;
 
         if(strcasecmp(strings[2], "sync") == 0) {
-            duplicate = false;
             resp = "sync";
         } else if(strcasecmp(strings[2], "status") == 0) {
             sendStatus();
             resp = "status";
         } else if(strcasecmp(strings[2], "freq") == 0 && index >= 4) {
             int freq = atoi(strings[3]);
-            if(!duplicate) setSendStatusFrequency(freq);
+            setSendStatusFrequency(freq);
             resp = "freq";
         } else if(strcasecmp(strings[2], "pwr") == 0 && index >= 4) {
             int power = atoi(strings[3]);
-            if(!duplicate) setTxPower(power);
+            setTxPower(power);
             resp = "pwr";
         } else if(strcasecmp(strings[2], "wifi") == 0) {
-            if(!duplicate) {
-                if (index >= 4 && strcasecmp(strings[3], "off") == 0) {
-                    disableWifi();
-                } else {
-                    const char *ssid = (index >= 4) ? strings[3] : WIFI_SSID;
-                    const char *pass = (index >= 5) ? strings[4] : WIFI_PASS;
-                    connectWifi(ssid, pass);
-                }
+            if (index >= 4 && strcasecmp(strings[3], "off") == 0) {
+                disableWifi();
+            } else {
+                const char *ssid = (index >= 4) ? strings[3] : WIFI_SSID;
+                const char *pass = (index >= 5) ? strings[4] : WIFI_PASS;
+                connectWifi(ssid, pass);
             }
             resp = "wifi";
         } else {
@@ -337,10 +331,9 @@ void Receiver::processReceived(char *rxpacket)
                 onTimeSec = 0;
             }
             mPulseMode = strcasecmp(strings[2], "pulse") == 0;
-            if(!duplicate) setRelayState(newRelayState);
+            setRelayState(newRelayState);
             resp = newRelayState ? (mPulseMode ? "pulse" : "on") : "off";
         }
-        if(!duplicate) lastCommandId = stateId;
         delay(200);
         sendAck(stateId, resp ? resp : "ok");
     }


### PR DESCRIPTION
## Summary
- process every command as received instead of skipping duplicates
- drop lastCommandId tracking from receivers

## Testing
- `pio check` (esp32-c3-receiver) *(fails: cppcheck failed to perform check)*
- `pio check` (heltec-controller-receiver)`

------
https://chatgpt.com/codex/tasks/task_e_689be6b00540832ba1de16dbb5f5fadf