### PR TITLE
Make LoRa sync word configurable via config files

### DIFF
--- a/esp32-c3-receiver/include/config.h
+++ b/esp32-c3-receiver/include/config.h
@@ -31,6 +31,7 @@
                                                               //  4: 4/8]
 #define LORA_PREAMBLE_LENGTH                        8         // Same for Tx and Rx
 #define LORA_SYMBOL_TIMEOUT                         0         // Symbols
+#define LORA_SYNC_WORD                              0x12
 #define LORA_FIX_LENGTH_PAYLOAD_ON                  false
 #define LORA_IQ_INVERSION_ON                        false
 

--- a/esp32-c3-receiver/src/controller.cpp
+++ b/esp32-c3-receiver/src/controller.cpp
@@ -271,6 +271,7 @@ void Controller::setup() {
     radio.setOutputPower(txPower);
     radio.setPreambleLength(LORA_PREAMBLE_LENGTH);
     radio.invertIQ(LORA_IQ_INVERSION_ON);
+    radio.setSyncWord(LORA_SYNC_WORD);
     if (LORA_FIX_LENGTH_PAYLOAD_ON) {
         radio.implicitHeader(LORA_SYMBOL_TIMEOUT);
     } else {

--- a/esp32-c3-receiver/src/receiver.cpp
+++ b/esp32-c3-receiver/src/receiver.cpp
@@ -254,6 +254,7 @@ void Receiver::setup()
     radio.setOutputPower(TX_OUTPUT_POWER);
     radio.setPreambleLength(LORA_PREAMBLE_LENGTH);
     radio.invertIQ(LORA_IQ_INVERSION_ON);
+    radio.setSyncWord(LORA_SYNC_WORD);
     if (LORA_FIX_LENGTH_PAYLOAD_ON)
     {
         radio.implicitHeader(LORA_SYMBOL_TIMEOUT);

--- a/heltec-controller-receiver/include/device-config.h
+++ b/heltec-controller-receiver/include/device-config.h
@@ -28,6 +28,7 @@
                                                               //  4: 4/8]
 #define LORA_PREAMBLE_LENGTH                        8         // Same for Tx and Rx
 #define LORA_SYMBOL_TIMEOUT                         0         // Symbols
+#define LORA_SYNC_WORD                              0x12
 #define LORA_FIX_LENGTH_PAYLOAD_ON                  false
 #define LORA_IQ_INVERSION_ON                        false
 

--- a/heltec-controller-receiver/src/controller.cpp
+++ b/heltec-controller-receiver/src/controller.cpp
@@ -418,6 +418,8 @@ void Controller::setup() {
                                    LORA_SYMBOL_TIMEOUT, LORA_FIX_LENGTH_PAYLOAD_ON,
                                    0, true, 0, 0, LORA_IQ_INVERSION_ON, true );
 
+    Radio.SetSyncWord(LORA_SYNC_WORD);
+
     // Begin in continuous receive mode so incoming packets are processed
     Radio.Rx( 0 );
 

--- a/heltec-controller-receiver/src/receiver.cpp
+++ b/heltec-controller-receiver/src/receiver.cpp
@@ -152,6 +152,8 @@ void Receiver::setup()
                       LORA_SYMBOL_TIMEOUT, LORA_FIX_LENGTH_PAYLOAD_ON,
                       0, true, 0, 0, LORA_IQ_INVERSION_ON, true);
 
+    Radio.SetSyncWord(LORA_SYNC_WORD);
+
     setIdle();
 
     Serial.println("Init Radio - complete");


### PR DESCRIPTION
## Summary
- Define `LORA_SYNC_WORD` in heltec and ESP32-C3 config headers
- Initialize radios with `LORA_SYNC_WORD` instead of hardcoded value

## Testing
- `pio run` *(heltec-controller-receiver: missing MQTT_USER/MQTT_PASS)*
- `pio run` *(esp32-c3-receiver: missing config-private.h)*

------
https://chatgpt.com/codex/tasks/task_e_689c37b2aa38832b8f9d28c14ac8b21d