### PR TITLE
Add receiver reboot command

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Flash the compiled firmware to two boards. Set `isController` as required before
 - `pump_station/wifi/connect` – ask the receiver to join the default WiFi network and enable OTA updates.
 - `pump_station/wifi/connect_custom` – payload `SSID:PASSWORD` to join a specific network for OTA.
 - `pump_station/wifi/disable` – disconnect the receiver from WiFi and disable OTA updates.
+- `pump_station/reboot` – instruct the receiver to reboot.
 
 ### Home Assistant Discovery
 

--- a/esp32-c3-receiver/src/controller.cpp
+++ b/esp32-c3-receiver/src/controller.cpp
@@ -199,6 +199,9 @@ void Controller::mqttCallback(char *topic, byte *payload, unsigned int length) {
         ++mStateId;
         sprintf(msg, "FREQ:%u", freq);
         enqueueMessage(msg);
+    } else if(strcmp(topic, "pump_station/reboot") == 0) {
+        ++mStateId;
+        enqueueMessage("REBOOT");
     }
 }
 
@@ -238,6 +241,7 @@ void Controller::ensureMqtt() {
                 mqttClient.subscribe("pump_station/tx_power/receiver/set");
                 mqttClient.subscribe("pump_station/status_freq/controller/set");
                 mqttClient.subscribe("pump_station/status_freq/receiver/set");
+                mqttClient.subscribe("pump_station/reboot");
                 sendDiscovery();
                 publishState();
                 publishControllerStatus();
@@ -456,6 +460,8 @@ void Controller::processReceived(char *rxpacket) {
                 unsigned int freq = atoi(strings[3]);
                 receiverStatusFreqSec = freq;
             } else if(strcasecmp(strings[2], "status") == 0) {
+                // no-op
+            } else if(strcasecmp(strings[2], "reboot") == 0) {
                 // no-op
             } else if(strcasecmp(strings[2], "wifi") == 0) {
                 // no-op

--- a/esp32-c3-receiver/src/receiver.cpp
+++ b/esp32-c3-receiver/src/receiver.cpp
@@ -616,7 +616,13 @@ void Receiver::processReceived(char *rxpacket)
         uint16_t stateId = atoi(strings[1]);
         const char *resp = NULL;
 
-        if(strcasecmp(strings[2], "sync") == 0) {
+        if(strcasecmp(strings[2], "reboot") == 0) {
+            delay(200);
+            sendAck(stateId, "reboot");
+            delay(100);
+            ESP.restart();
+            return;
+        } else if(strcasecmp(strings[2], "sync") == 0) {
             resp = "sync";
         } else if(strcasecmp(strings[2], "status") == 0) {
             sendStatus();

--- a/heltec-controller-receiver/src/controller.cpp
+++ b/heltec-controller-receiver/src/controller.cpp
@@ -260,6 +260,9 @@ void Controller::mqttCallback(char *topic, byte *payload, unsigned int length) {
     } else if(strcmp(topic, "pump_station/wifi/disable") == 0) {
         ++mStateId;
         sendMessage("WIFI:OFF");
+    } else if(strcmp(topic, "pump_station/reboot") == 0) {
+        ++mStateId;
+        sendMessage("REBOOT");
     } else if(strcmp(topic, "pump_station/switch/state") == 0) {
         initialStateReceived = true;
         retainedStateOn = cmd.startsWith("ON");
@@ -355,6 +358,7 @@ void Controller::ensureMqtt() {
     mqttClient.subscribe("pump_station/wifi/connect");
     mqttClient.subscribe("pump_station/wifi/connect_custom");
     mqttClient.subscribe("pump_station/wifi/disable");
+    mqttClient.subscribe("pump_station/reboot");
     mqttClient.subscribe("pump_station/switch/state");
 
     // Process any retained messages (such as the last set command or state)
@@ -703,6 +707,10 @@ void Controller::processReceived(char *rxpacket)
             else if(strcasecmp(strings[2], "status") == 0)
             {
                 Serial.println("Status command acknowledged");
+            }
+            else if(strcasecmp(strings[2], "reboot") == 0)
+            {
+                Serial.println("Receiver rebooting");
             }
             else if(strcasecmp(strings[2], "wifi") == 0)
             {

--- a/heltec-controller-receiver/src/receiver.cpp
+++ b/heltec-controller-receiver/src/receiver.cpp
@@ -300,7 +300,13 @@ void Receiver::processReceived(char *rxpacket)
         uint16_t stateId = atoi(strings[1]);
         const char *resp = NULL;
 
-        if(strcasecmp(strings[2], "sync") == 0) {
+        if(strcasecmp(strings[2], "reboot") == 0) {
+            delay(200);
+            sendAck(stateId, "reboot");
+            delay(100);
+            ESP.restart();
+            return;
+        } else if(strcasecmp(strings[2], "sync") == 0) {
             resp = "sync";
         } else if(strcasecmp(strings[2], "status") == 0) {
             sendStatus();


### PR DESCRIPTION
## Summary
- add MQTT-based reboot command for the receiver
- handle reboot acknowledgements in controller
- implement reboot processing on receiver side

## Testing
- `pio run` (heltec-controller-receiver)
- `pio run` (esp32-c3-receiver) *(fails: various undefined macros)*

------
https://chatgpt.com/codex/tasks/task_e_689c50a189b8832b97aff085327f3970