### PR TITLE
Add messaging and uptime statistics

### DIFF
--- a/esp32-c3-receiver/include/controller.h
+++ b/esp32-c3-receiver/include/controller.h
@@ -11,6 +11,14 @@
 
 struct DailyStats;
 
+struct StatsWindow {
+    unsigned long start = 0;
+    unsigned long msgsSent = 0;
+    unsigned long msgsReceived = 0;
+    unsigned long bytesSent = 0;
+    unsigned long bytesReceived = 0;
+};
+
 enum RelayState
 {
     UNKNOWN,
@@ -67,7 +75,7 @@ private:
 
     void publishControllerStatus();
     void publishReceiverStatus(int power, int rssi, int snr, bool relay, bool pulse, float battery,
-                               int chargeState, int wifi);
+                               int chargeState, int wifi, unsigned long uptime);
     void publishReceiverDailyStats(const struct DailyStats &stats);
 
     void setSendStatusFrequency(unsigned int freq);
@@ -106,6 +114,18 @@ private:
     // Tracks the retained pump_station/switch/state value at startup
     bool initialStateReceived = false;
     bool retainedStateOn = false;
+
+    // Statistics helpers
+    void publishStatistics();
+    void updateStats(size_t bytes, bool sent);
+    void resetWindow(StatsWindow &w, unsigned long now, unsigned long period);
+
+    StatsWindow minuteStats;
+    StatsWindow hourStats;
+    StatsWindow dayStats;
+    unsigned long bootTime = 0;
+    unsigned long receiverUptimeSec = 0;
+    unsigned long lastStatsPublish = 0;
 
     void publishState();
     void sendDiscovery();

--- a/esp32-c3-receiver/src/receiver.cpp
+++ b/esp32-c3-receiver/src/receiver.cpp
@@ -423,7 +423,7 @@ void Receiver::sendHello()
 void Receiver::sendStatus()
 {
     updateStatusCache();
-    sprintf(txpacket, "S:%d:%d:%d:%d:%d:%.1f:%d:%d", txPower, mLastRssi, mLastSnr, mRelayState ? 1 : 0, mPulseMode ? 1 : 0, lastBatteryPct, static_cast<int>(lastChargeState), lastWifiState);
+    sprintf(txpacket, "S:%d:%d:%d:%d:%d:%.1f:%d:%d:%lu", txPower, mLastRssi, mLastSnr, mRelayState ? 1 : 0, mPulseMode ? 1 : 0, lastBatteryPct, static_cast<int>(lastChargeState), lastWifiState, millis() / 1000UL);
 
     pendingDailyStats = true;
     send(txpacket, strlen(txpacket));

--- a/heltec-controller-receiver/include/controller.h
+++ b/heltec-controller-receiver/include/controller.h
@@ -13,6 +13,14 @@
 
 struct DailyStats;
 
+struct StatsWindow {
+    unsigned long start = 0;
+    unsigned long msgsSent = 0;
+    unsigned long msgsReceived = 0;
+    unsigned long bytesSent = 0;
+    unsigned long bytesReceived = 0;
+};
+
 enum RelayState
 {
     UNKNOWN,
@@ -73,7 +81,7 @@ private:
 
     void publishControllerStatus();
     void publishReceiverStatus(int power, int rssi, int snr, bool relay, bool pulse, float battery,
-                               int chargeState, int wifi);
+                               int chargeState, int wifi, unsigned long uptime);
     void publishReceiverDailyStats(const struct DailyStats &stats);
 
     void setSendStatusFrequency(unsigned int freq);
@@ -113,7 +121,18 @@ private:
     bool initialStateReceived = false;
     bool retainedStateOn = false;
 
-    // unsigned int messageNumnber = 0;
+    // Statistics helpers
+    void publishStatistics();
+    void updateStats(size_t bytes, bool sent);
+    void resetWindow(StatsWindow &w, unsigned long now, unsigned long period);
+
+    StatsWindow minuteStats;
+    StatsWindow hourStats;
+    StatsWindow dayStats;
+    unsigned long bootTime = 0;
+    unsigned long receiverUptimeSec = 0;
+    unsigned long lastStatsPublish = 0;
+
     void publishState();
     void sendDiscovery();
 };

--- a/heltec-controller-receiver/src/receiver.cpp
+++ b/heltec-controller-receiver/src/receiver.cpp
@@ -204,7 +204,7 @@ void Receiver::sendStatus()
     {
         wifi = WIFI_ERROR;
     }
-    sprintf(txpacket, "S:%d:%d:%d:%d:%d:%.1f:%d:%d", txPower, mLastRssi, mLastSnr, mRelayState ? 1 : 0, mPulseMode ? 1 : 0, b, state, wifi);
+    sprintf(txpacket, "S:%d:%d:%d:%d:%d:%.1f:%d:%d:%lu", txPower, mLastRssi, mLastSnr, mRelayState ? 1 : 0, mPulseMode ? 1 : 0, b, state, wifi, millis() / 1000UL);
     Serial.printf("Sending status \"%s\", length %d\r\n", txpacket, strlen(txpacket));
     lora_idle = false;
     Radio.Send((uint8_t *)txpacket, strlen(txpacket));


### PR DESCRIPTION
## Summary
- track sent/received message and byte counts for minute/hour/day windows
- report controller and receiver uptime along with messaging stats via MQTT
- include receiver uptime in status transmissions

## Testing
- `pio run` *(fails: 'WIFI_SSID' was not declared)*
- `cd esp32-c3-receiver && pio run` *(fails: missing config-private.h)*

------
https://chatgpt.com/codex/tasks/task_e_689c65e521b0832ba15fb60113c01879