### PR TITLE
feat: make statistics use moving window

### DIFF
--- a/esp32-c3-receiver/include/controller.h
+++ b/esp32-c3-receiver/include/controller.h
@@ -12,11 +12,45 @@
 struct DailyStats;
 
 struct StatsWindow {
-    unsigned long start = 0;
+    struct Event {
+        unsigned long time;
+        size_t bytes;
+        bool sent;
+    };
+    unsigned long period;
+    std::deque<Event> events;
     unsigned long msgsSent = 0;
     unsigned long msgsReceived = 0;
     unsigned long bytesSent = 0;
     unsigned long bytesReceived = 0;
+
+    explicit StatsWindow(unsigned long p = 0) : period(p) {}
+
+    void add(unsigned long now, size_t bytes, bool sent) {
+        events.push_back({now, bytes, sent});
+        if (sent) {
+            msgsSent++;
+            bytesSent += bytes;
+        } else {
+            msgsReceived++;
+            bytesReceived += bytes;
+        }
+        prune(now);
+    }
+
+    void prune(unsigned long now) {
+        while (!events.empty() && now - events.front().time >= period) {
+            const auto &e = events.front();
+            if (e.sent) {
+                msgsSent--;
+                bytesSent -= e.bytes;
+            } else {
+                msgsReceived--;
+                bytesReceived -= e.bytes;
+            }
+            events.pop_front();
+        }
+    }
 };
 
 enum RelayState
@@ -118,11 +152,10 @@ private:
     // Statistics helpers
     void publishStatistics();
     void updateStats(size_t bytes, bool sent);
-    void resetWindow(StatsWindow &w, unsigned long now, unsigned long period);
-
-    StatsWindow minuteStats;
-    StatsWindow hourStats;
-    StatsWindow dayStats;
+    
+    StatsWindow minuteStats{60000UL};
+    StatsWindow hourStats{3600000UL};
+    StatsWindow dayStats{86400000UL};
     unsigned long bootTime = 0;
     unsigned long receiverUptimeSec = 0;
     unsigned long lastStatsPublish = 0;

--- a/heltec-controller-receiver/src/controller.cpp
+++ b/heltec-controller-receiver/src/controller.cpp
@@ -188,35 +188,18 @@ void Controller::publishReceiverDailyStats(const DailyStats &stats) {
     mqttClient.publish("pump_station/status/receiver/battery_daily", payload, true);
 }
 
-void Controller::resetWindow(StatsWindow &w, unsigned long now, unsigned long period) {
-    if (w.start == 0 || now - w.start >= period) {
-        w.start = now;
-        w.msgsSent = w.msgsReceived = w.bytesSent = w.bytesReceived = 0;
-    }
-}
-
 void Controller::updateStats(size_t bytes, bool sent) {
     unsigned long now = millis();
-    resetWindow(minuteStats, now, 60000UL);
-    resetWindow(hourStats, now, 3600000UL);
-    resetWindow(dayStats, now, 86400000UL);
-    StatsWindow *windows[3] = {&minuteStats, &hourStats, &dayStats};
-    for (auto w : windows) {
-        if (sent) {
-            w->msgsSent++;
-            w->bytesSent += bytes;
-        } else {
-            w->msgsReceived++;
-            w->bytesReceived += bytes;
-        }
-    }
+    minuteStats.add(now, bytes, sent);
+    hourStats.add(now, bytes, sent);
+    dayStats.add(now, bytes, sent);
 }
 
 void Controller::publishStatistics() {
     unsigned long now = millis();
-    resetWindow(minuteStats, now, 60000UL);
-    resetWindow(hourStats, now, 3600000UL);
-    resetWindow(dayStats, now, 86400000UL);
+    minuteStats.prune(now);
+    hourStats.prune(now);
+    dayStats.prune(now);
     unsigned long uptime = (now - bootTime) / 1000UL;
     char payload[256];
     snprintf(payload, sizeof(payload),
@@ -425,7 +408,6 @@ void Controller::ensureMqtt() {
 void Controller::setup() {
     Settings::begin();
     bootTime = millis();
-    minuteStats.start = hourStats.start = dayStats.start = bootTime;
     txPower = Settings::getInt(KEY_CTRL_TX_POWER, TX_OUTPUT_POWER);
     receiverTxPower = Settings::getInt(KEY_RX_TX_POWER, TX_OUTPUT_POWER);
     statusSendFreqSec = Settings::getInt(KEY_CTRL_STATUS_FREQ, DEFAULT_STATUS_SEND_FREQ_SEC);


### PR DESCRIPTION
## Summary
- track message stats with deque-based sliding windows
- remove periodic resets for minute/hour/day statistics

## Testing
- `pio run -d heltec-controller-receiver` *(fails: WIFI_SSID not declared)*
- `pio run -d esp32-c3-receiver` *(fails: config-private.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_689c6fb99360832bb865a319040053be