### PR TITLE
Increase MQTT payload size for controller stats

### DIFF
--- a/esp32-c3-receiver/platformio.ini
+++ b/esp32-c3-receiver/platformio.ini
@@ -24,6 +24,6 @@ framework = arduino
 lib_deps = jgromes/RadioLib
     knolleary/PubSubClient
 monitor_speed = 115200
-build_flags = -I include -DMQTT_MAX_PACKET_SIZE=2048
+build_flags = -I include -DMQTT_MAX_PACKET_SIZE=4096
 
 ; build_flags = -DRADIOLIB_DEBUG_BASIC 

--- a/esp32-c3-receiver/src/controller.cpp
+++ b/esp32-c3-receiver/src/controller.cpp
@@ -169,7 +169,7 @@ void Controller::publishStatistics() {
     hourStats.prune(now);
     dayStats.prune(now);
     unsigned long uptime = (now - bootTime) / 1000UL;
-    char payload[256];
+    char payload[512];
     snprintf(payload, sizeof(payload),
              "{\"uptime\":%lu,\"receiver_uptime\":%lu,\"msg_sent_min\":%lu,\"msg_recv_min\":%lu,\"bytes_sent_min\":%lu,\"bytes_recv_min\":%lu,\"msg_sent_hr\":%lu,\"msg_recv_hr\":%lu,\"bytes_sent_hr\":%lu,\"bytes_recv_hr\":%lu,\"msg_sent_day\":%lu,\"msg_recv_day\":%lu,\"bytes_sent_day\":%lu,\"bytes_recv_day\":%lu}",
              uptime, receiverUptimeSec,

--- a/heltec-controller-receiver/platformio.ini
+++ b/heltec-controller-receiver/platformio.ini
@@ -19,9 +19,9 @@ lib_deps =
 	eiannone/Heltec_Esp32_LoRaWan@^0.7.0
     adafruit/Adafruit SSD1306@^2.5.15    
 lib_ldf_mode = deep
-build_flags = 
-    -DMQTT_MAX_PACKET_SIZE=2048
-	-DWIFI_LORA_32_V3=1
+build_flags =
+    -DMQTT_MAX_PACKET_SIZE=4096
+        -DWIFI_LORA_32_V3=1
 #    -D LORA_DISPLAY
 	-D LoRaWAN_DEBUG_LEVEL=3
 	-D LORAWAN_PREAMBLE_LENGTH=8

--- a/heltec-controller-receiver/src/controller.cpp
+++ b/heltec-controller-receiver/src/controller.cpp
@@ -201,7 +201,7 @@ void Controller::publishStatistics() {
     hourStats.prune(now);
     dayStats.prune(now);
     unsigned long uptime = (now - bootTime) / 1000UL;
-    char payload[256];
+    char payload[512];
     snprintf(payload, sizeof(payload),
              "{\"uptime\":%lu,\"receiver_uptime\":%lu,\"msg_sent_min\":%lu,\"msg_recv_min\":%lu,\"bytes_sent_min\":%lu,\"bytes_recv_min\":%lu,\"msg_sent_hr\":%lu,\"msg_recv_hr\":%lu,\"bytes_sent_hr\":%lu,\"bytes_recv_hr\":%lu,\"msg_sent_day\":%lu,\"msg_recv_day\":%lu,\"bytes_sent_day\":%lu,\"bytes_recv_day\":%lu}",
              uptime, receiverUptimeSec,


### PR DESCRIPTION
## Summary
- expand stats message buffer to 512 bytes for both controllers
- raise MQTT_MAX_PACKET_SIZE to 4096 in platformio builds

## Testing
- `pio run -e controller` *(fails: 'WIFI_SSID' not declared)*
- `pio run -e lolin_c3_mini` *(fails: missing config-private.h)*

------
https://chatgpt.com/codex/tasks/task_e_689c779a63ac832b84a29cb5946a895b