### PR TITLE
feat: expose stats in home assistant

### DIFF
--- a/esp32-c3-receiver/src/controller.cpp
+++ b/esp32-c3-receiver/src/controller.cpp
@@ -246,6 +246,8 @@ void Controller::sendDiscovery() {
     mqttClient.publish("homeassistant/sensor/pump_station_rx_status/config", rxStatusPayload, true);
     const char *rxBattDailyPayload = "{\"name\":\"Receiver Battery Daily\",\"state_topic\":\"pump_station/status/receiver/battery_daily\",\"value_template\":\"{{ value_json.avgV }}\",\"json_attributes_topic\":\"pump_station/status/receiver/battery_daily\",\"unique_id\":\"pump_station_batt_daily\"}";
     mqttClient.publish("homeassistant/sensor/pump_station_batt_daily/config", rxBattDailyPayload, true);
+    const char *statsPayload = "{\"name\":\"Pump Stats\",\"state_topic\":\"pump_station/status/stats\",\"value_template\":\"{{ value_json.uptime }}\",\"unit_of_measurement\":\"s\",\"json_attributes_topic\":\"pump_station/status/stats\",\"unique_id\":\"pump_station_stats\"}";
+    mqttClient.publish("homeassistant/sensor/pump_station_stats/config", statsPayload, true);
 }
 
 void Controller::ensureMqtt() {

--- a/heltec-controller-receiver/src/controller.cpp
+++ b/heltec-controller-receiver/src/controller.cpp
@@ -334,6 +334,9 @@ void Controller::sendDiscovery() {
     const char *rxBattDailyTopic = "homeassistant/sensor/pump_station_batt_daily/config";
     const char *rxBattDailyPayload = "{\"name\":\"Receiver Battery Daily\",\"state_topic\":\"pump_station/status/receiver/battery_daily\",\"value_template\":\"{{ value_json.avgV }}\",\"json_attributes_topic\":\"pump_station/status/receiver/battery_daily\",\"unique_id\":\"pump_station_batt_daily\",\"device\":{\"identifiers\":[\"pump_station\"],\"name\":\"Pump Controller\",\"model\":\"Heltec WiFi LoRa 32 V3\",\"manufacturer\":\"Heltec\"}}";
     mqttClient.publish(rxBattDailyTopic, rxBattDailyPayload, true);
+    const char *statsTopic = "homeassistant/sensor/pump_station_stats/config";
+    const char *statsPayload = "{\"name\":\"Pump Stats\",\"state_topic\":\"pump_station/status/stats\",\"value_template\":\"{{ value_json.uptime }}\",\"unit_of_measurement\":\"s\",\"json_attributes_topic\":\"pump_station/status/stats\",\"unique_id\":\"pump_station_stats\",\"device\":{\"identifiers\":[\"pump_station\"],\"name\":\"Pump Controller\",\"model\":\"Heltec WiFi LoRa 32 V3\",\"manufacturer\":\"Heltec\"}}";
+    mqttClient.publish(statsTopic, statsPayload, true);
 }
 
 


### PR DESCRIPTION
## Summary
- publish an MQTT discovery config for pump statistics so Home Assistant can attach attributes

## Testing
- `pio run` *(fails: config-private.h: No such file or directory)*
- `pio run` *(heltec-controller-receiver; fails: MQTT_USER was not declared in this scope)*

------
https://chatgpt.com/codex/tasks/task_e_689d171bb364832bb5c78803f46689f2