### PR TITLE
Track total messages in controller stats

### DIFF
--- a/esp32-c3-receiver/include/controller.h
+++ b/esp32-c3-receiver/include/controller.h
@@ -152,10 +152,12 @@ private:
     // Statistics helpers
     void publishStatistics();
     void updateStats(size_t bytes, bool sent);
-    
+
     StatsWindow minuteStats{60000UL};
     StatsWindow hourStats{3600000UL};
     StatsWindow dayStats{86400000UL};
+    unsigned long totalMsgsSent = 0;
+    unsigned long totalMsgsReceived = 0;
     unsigned long bootTime = 0;
     unsigned long receiverUptimeSec = 0;
     unsigned long lastStatsPublish = 0;

--- a/esp32-c3-receiver/src/controller.cpp
+++ b/esp32-c3-receiver/src/controller.cpp
@@ -158,6 +158,11 @@ void Controller::publishReceiverDailyStats(const DailyStats &stats) {
 
 void Controller::updateStats(size_t bytes, bool sent) {
     unsigned long now = millis();
+    if (sent) {
+        totalMsgsSent++;
+    } else {
+        totalMsgsReceived++;
+    }
     minuteStats.add(now, bytes, sent);
     hourStats.add(now, bytes, sent);
     dayStats.add(now, bytes, sent);
@@ -171,14 +176,15 @@ void Controller::publishStatistics() {
     unsigned long uptime = (now - bootTime) / 1000UL;
     char payload[512];
     snprintf(payload, sizeof(payload),
-             "{\"uptime\":%lu,\"receiver_uptime\":%lu,\"msg_sent_min\":%lu,\"msg_recv_min\":%lu,\"bytes_sent_min\":%lu,\"bytes_recv_min\":%lu,\"msg_sent_hr\":%lu,\"msg_recv_hr\":%lu,\"bytes_sent_hr\":%lu,\"bytes_recv_hr\":%lu,\"msg_sent_day\":%lu,\"msg_recv_day\":%lu,\"bytes_sent_day\":%lu,\"bytes_recv_day\":%lu}",
+             "{\"uptime\":%lu,\"receiver_uptime\":%lu,\"msg_sent_min\":%lu,\"msg_recv_min\":%lu,\"bytes_sent_min\":%lu,\"bytes_recv_min\":%lu,\"msg_sent_hr\":%lu,\"msg_recv_hr\":%lu,\"bytes_sent_hr\":%lu,\"bytes_recv_hr\":%lu,\"msg_sent_day\":%lu,\"msg_recv_day\":%lu,\"bytes_sent_day\":%lu,\"bytes_recv_day\":%lu,\"msg_sent_total\":%lu,\"msg_recv_total\":%lu}",
              uptime, receiverUptimeSec,
              minuteStats.msgsSent, minuteStats.msgsReceived,
              minuteStats.bytesSent, minuteStats.bytesReceived,
              hourStats.msgsSent, hourStats.msgsReceived,
              hourStats.bytesSent, hourStats.bytesReceived,
              dayStats.msgsSent, dayStats.msgsReceived,
-             dayStats.bytesSent, dayStats.bytesReceived);
+             dayStats.bytesSent, dayStats.bytesReceived,
+             totalMsgsSent, totalMsgsReceived);
     mqttClient.publish("pump_station/status/stats", payload, true);
 }
 

--- a/heltec-controller-receiver/include/controller.h
+++ b/heltec-controller-receiver/include/controller.h
@@ -162,6 +162,8 @@ private:
     StatsWindow minuteStats{60000UL};
     StatsWindow hourStats{3600000UL};
     StatsWindow dayStats{86400000UL};
+    unsigned long totalMsgsSent = 0;
+    unsigned long totalMsgsReceived = 0;
     unsigned long bootTime = 0;
     unsigned long receiverUptimeSec = 0;
     unsigned long lastStatsPublish = 0;

--- a/heltec-controller-receiver/src/controller.cpp
+++ b/heltec-controller-receiver/src/controller.cpp
@@ -190,6 +190,11 @@ void Controller::publishReceiverDailyStats(const DailyStats &stats) {
 
 void Controller::updateStats(size_t bytes, bool sent) {
     unsigned long now = millis();
+    if (sent) {
+        totalMsgsSent++;
+    } else {
+        totalMsgsReceived++;
+    }
     minuteStats.add(now, bytes, sent);
     hourStats.add(now, bytes, sent);
     dayStats.add(now, bytes, sent);
@@ -203,14 +208,15 @@ void Controller::publishStatistics() {
     unsigned long uptime = (now - bootTime) / 1000UL;
     char payload[512];
     snprintf(payload, sizeof(payload),
-             "{\"uptime\":%lu,\"receiver_uptime\":%lu,\"msg_sent_min\":%lu,\"msg_recv_min\":%lu,\"bytes_sent_min\":%lu,\"bytes_recv_min\":%lu,\"msg_sent_hr\":%lu,\"msg_recv_hr\":%lu,\"bytes_sent_hr\":%lu,\"bytes_recv_hr\":%lu,\"msg_sent_day\":%lu,\"msg_recv_day\":%lu,\"bytes_sent_day\":%lu,\"bytes_recv_day\":%lu}",
+             "{\"uptime\":%lu,\"receiver_uptime\":%lu,\"msg_sent_min\":%lu,\"msg_recv_min\":%lu,\"bytes_sent_min\":%lu,\"bytes_recv_min\":%lu,\"msg_sent_hr\":%lu,\"msg_recv_hr\":%lu,\"bytes_sent_hr\":%lu,\"bytes_recv_hr\":%lu,\"msg_sent_day\":%lu,\"msg_recv_day\":%lu,\"bytes_sent_day\":%lu,\"bytes_recv_day\":%lu,\"msg_sent_total\":%lu,\"msg_recv_total\":%lu}",
              uptime, receiverUptimeSec,
              minuteStats.msgsSent, minuteStats.msgsReceived,
              minuteStats.bytesSent, minuteStats.bytesReceived,
              hourStats.msgsSent, hourStats.msgsReceived,
              hourStats.bytesSent, hourStats.bytesReceived,
              dayStats.msgsSent, dayStats.msgsReceived,
-             dayStats.bytesSent, dayStats.bytesReceived);
+             dayStats.bytesSent, dayStats.bytesReceived,
+             totalMsgsSent, totalMsgsReceived);
     mqttClient.publish("pump_station/status/stats", payload, true);
 }
 


### PR DESCRIPTION
## Summary
- track total sent and received message counts in controller stats
- include total message counters in stats payloads

## Testing
- `pio test` *(fails: Nothing to build. Please put your test suites to the '/workspace/esp32-sx1262-lora-relay/heltec-controller-receiver/test' folder)*
- `pio run` *(fails: 'MQTT_USER' was not declared in this scope)*
- `pio run` *(fails: fatal error: config-private.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689d1d3993c0832b8ac4687204ec91e0