### PR TITLE
Align ESP32-C3 status interval with Heltec controller

### DIFF
--- a/esp32-c3-receiver/include/config.h
+++ b/esp32-c3-receiver/include/config.h
@@ -44,7 +44,7 @@
 #define DEFAULT_ON_TIME_SEC                         300
 
 // Default frequency in seconds to send a status update
-#define DEFAULT_STATUS_SEND_FREQ_SEC                300
+#define DEFAULT_STATUS_SEND_FREQ_SEC                60
 
 // Minimum percent change in battery level before sending an immediate status
 // update. Smaller fluctuations are ignored to reduce chatter.


### PR DESCRIPTION
## Summary
- set ESP32-C3's default status send frequency to 60 seconds to match Heltec implementation

## Testing
- `pio run -d esp32-c3-receiver` *(fails: config-private.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689d7d055660832bb6cbc7f0fe47fcd9