### PR TITLE
feat: add MQTT topic to request receiver status

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Flash the compiled firmware to your ESP32-C3 boards. One board should be built w
 - `pump_station/wifi/connect_custom` – payload `SSID:PASSWORD` to join a specific network for OTA.
 - `pump_station/wifi/disable` – disconnect the receiver from WiFi and disable OTA updates.
 - `pump_station/reboot` – instruct the receiver to reboot.
+- `pump_station/status/request` – ask the receiver to immediately send status and battery info.
 - `pump_station/switch/state` – retained state topic used by the controller to resume the last relay state.
 
 The controller publishes status updates to:
@@ -47,5 +48,6 @@ When the controller connects to MQTT it publishes discovery messages so Home Ass
 - `switch` – pump on/off control.
 - `number` – `Pump Pulse`, `Controller Tx Power` and `Receiver Tx Power`.
 - `sensor` – `Controller Status`, `Receiver Status`, `Receiver Battery Daily` and `Pump Stats`.
+- `button` – request receiver status updates on demand.
 
 Each discovery message references the MQTT topics listed above.

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -260,6 +260,9 @@ void Controller::mqttCallback(char *topic, byte *payload, unsigned int length) {
     } else if(strcmp(topic, "pump_station/reboot") == 0) {
         ++mStateId;
         enqueueMessage("REBOOT");
+    } else if(strcmp(topic, "pump_station/status/request") == 0) {
+        ++mStateId;
+        enqueueMessage("STATUS");
     } else if(strcmp(topic, "pump_station/switch/state") == 0) {
         initialStateReceived = true;
         retainedStateOn = cmd.startsWith("ON");
@@ -295,6 +298,10 @@ void Controller::sendDiscovery() {
     const char *rxBattDailyPayload = "{\"name\":\"Receiver Battery Daily\",\"state_topic\":\"pump_station/status/receiver/battery_daily\",\"value_template\":\"{{ value_json.avgV }}\",\"json_attributes_topic\":\"pump_station/status/receiver/battery_daily\",\"unique_id\":\"pump_station_batt_daily\",\"device\":{\"identifiers\":[\"pump_station\"],\"name\":\"Pump Controller\",\"model\":\"ESP32-C3 SX1262\",\"manufacturer\":\"Espressif\"}}";
     mqttClient.publish(rxBattDailyTopic, rxBattDailyPayload, true);
 
+    const char *statusReqTopic = "homeassistant/button/pump_station_status_request/config";
+    const char *statusReqPayload = "{\"name\":\"Request Receiver Status\",\"command_topic\":\"pump_station/status/request\",\"payload_press\":\"1\",\"unique_id\":\"pump_station_status_request\",\"device\":{\"identifiers\":[\"pump_station\"],\"name\":\"Pump Controller\",\"model\":\"ESP32-C3 SX1262\",\"manufacturer\":\"Espressif\"}}";
+    mqttClient.publish(statusReqTopic, statusReqPayload, true);
+
     const char *statsTopic = "homeassistant/sensor/pump_station_stats/config";
     const char *statsPayload = "{\"name\":\"Pump Stats\",\"state_topic\":\"pump_station/status/stats\",\"value_template\":\"{{ value_json.uptime }}\",\"unit_of_measurement\":\"s\",\"json_attributes_topic\":\"pump_station/status/stats\",\"unique_id\":\"pump_station_stats\",\"device\":{\"identifiers\":[\"pump_station\"],\"name\":\"Pump Controller\",\"model\":\"ESP32-C3 SX1262\",\"manufacturer\":\"Espressif\"}}";
     mqttClient.publish(statsTopic, statsPayload, true);
@@ -323,6 +330,7 @@ void Controller::ensureMqtt() {
                 mqttClient.subscribe("pump_station/wifi/connect_custom");
                 mqttClient.subscribe("pump_station/wifi/disable");
                 mqttClient.subscribe("pump_station/reboot");
+                mqttClient.subscribe("pump_station/status/request");
                 mqttClient.subscribe("pump_station/switch/state");
 
                 // Process retained messages for last command or state


### PR DESCRIPTION
## Summary
- allow controller to handle `pump_station/status/request` MQTT command and forward status request to receiver
- expose Home Assistant discovery button for on-demand receiver status

## Testing
- `pio run`

------
https://chatgpt.com/codex/tasks/task_e_689e878e6c54832b8cbcbaf8fa479e04