### PR TITLE
Expose receiver WiFi and reboot commands as HA buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A LoRa-based pump control system built around a generic ESP32-C3 board paired wi
 
 ## Building
 
-1. Copy `include/config-example.h` to `include/config-private.h` and update it with your WiFi and MQTT settings.
+1. Copy `include/config-example.h` to `include/config-private.h` and update it with your WiFi, optional custom WiFi and MQTT settings.
 2. Edit `src/main.cpp` and set `isController` to `true` for the controller firmware or `false` for the receiver.
 3. Build the firmware with PlatformIO:
 
@@ -48,6 +48,6 @@ When the controller connects to MQTT it publishes discovery messages so Home Ass
 - `switch` – pump on/off control.
 - `number` – `Pump Pulse`, `Controller Tx Power` and `Receiver Tx Power`.
 - `sensor` – `Controller Status`, `Receiver Status`, `Receiver Battery Daily` and `Pump Stats`.
-- `button` – request receiver status updates on demand.
+- `button` – `Request Receiver Status`, `Receiver Connect Wifi`, `Receiver Connect Custom Wifi` and `Receiver Reboot`.
 
 Each discovery message references the MQTT topics listed above.

--- a/include/config-example.h
+++ b/include/config-example.h
@@ -8,6 +8,9 @@
 #define WIFI_SSID "your ssid"
 #define WIFI_PASS "your wifi pass"
 
+#define WIFI_CUSTOM_SSID "custom wifi ssid"
+#define WIFI_CUSTOM_PASS "custom wifi pass"
+
 #define MQTT_SERVER "192.168.1.11"
 #define MQTT_PORT "1883"
 #define MQTT_USER "mqtt_user"

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -302,6 +302,18 @@ void Controller::sendDiscovery() {
     const char *statusReqPayload = "{\"name\":\"Request Receiver Status\",\"command_topic\":\"pump_station/status/request\",\"payload_press\":\"1\",\"unique_id\":\"pump_station_status_request\",\"device\":{\"identifiers\":[\"pump_station\"],\"name\":\"Pump Controller\",\"model\":\"ESP32-C3 SX1262\",\"manufacturer\":\"Espressif\"}}";
     mqttClient.publish(statusReqTopic, statusReqPayload, true);
 
+    const char *wifiConnTopic = "homeassistant/button/pump_station_wifi_connect/config";
+    const char *wifiConnPayload = "{\"name\":\"Receiver Connect Wifi\",\"command_topic\":\"pump_station/wifi/connect\",\"payload_press\":\"1\",\"unique_id\":\"pump_station_wifi_connect\",\"device\":{\"identifiers\":[\"pump_station\"],\"name\":\"Pump Controller\",\"model\":\"ESP32-C3 SX1262\",\"manufacturer\":\"Espressif\"}}";
+    mqttClient.publish(wifiConnTopic, wifiConnPayload, true);
+
+    const char *wifiCustomTopic = "homeassistant/button/pump_station_wifi_connect_custom/config";
+    const char *wifiCustomPayload = "{\"name\":\"Receiver Connect Custom Wifi\",\"command_topic\":\"pump_station/wifi/connect_custom\",\"payload_press\":\"" WIFI_CUSTOM_SSID ":" WIFI_CUSTOM_PASS "\",\"unique_id\":\"pump_station_wifi_connect_custom\",\"device\":{\"identifiers\":[\"pump_station\"],\"name\":\"Pump Controller\",\"model\":\"ESP32-C3 SX1262\",\"manufacturer\":\"Espressif\"}}";
+    mqttClient.publish(wifiCustomTopic, wifiCustomPayload, true);
+
+    const char *rebootTopic = "homeassistant/button/pump_station_reboot/config";
+    const char *rebootPayload = "{\"name\":\"Receiver Reboot\",\"command_topic\":\"pump_station/reboot\",\"payload_press\":\"1\",\"unique_id\":\"pump_station_reboot\",\"device\":{\"identifiers\":[\"pump_station\"],\"name\":\"Pump Controller\",\"model\":\"ESP32-C3 SX1262\",\"manufacturer\":\"Espressif\"}}";
+    mqttClient.publish(rebootTopic, rebootPayload, true);
+
     const char *statsTopic = "homeassistant/sensor/pump_station_stats/config";
     const char *statsPayload = "{\"name\":\"Pump Stats\",\"state_topic\":\"pump_station/status/stats\",\"value_template\":\"{{ value_json.uptime }}\",\"unit_of_measurement\":\"s\",\"json_attributes_topic\":\"pump_station/status/stats\",\"unique_id\":\"pump_station_stats\",\"device\":{\"identifiers\":[\"pump_station\"],\"name\":\"Pump Controller\",\"model\":\"ESP32-C3 SX1262\",\"manufacturer\":\"Espressif\"}}";
     mqttClient.publish(statsTopic, statsPayload, true);


### PR DESCRIPTION
## Summary
- add Home Assistant MQTT buttons for receiver WiFi connect, custom connect, and reboot commands
- document new buttons and custom WiFi config options

## Testing
- `pio run`

------
https://chatgpt.com/codex/tasks/task_e_689e8ab5c948832bb10cd31972cbaa96