### PR TITLE
Fix repeated status requests by sending ack before status

### DIFF
--- a/include/receiver.h
+++ b/include/receiver.h
@@ -48,6 +48,7 @@ class Receiver : public Device
     unsigned int statusSendFreqSec = DEFAULT_RECEIVER_STATUS_SEND_FREQ_SEC;
     unsigned long lastStatusSend = 0;
     bool pendingDailyStats = false;
+    bool pendingStatus = false;
     bool mIsTransmitting = false;
     float lastBatteryPct = -1;
     ChargeState lastChargeState = DISCHARGING;

--- a/src/receiver.cpp
+++ b/src/receiver.cpp
@@ -625,8 +625,9 @@ void Receiver::processReceived(char *rxpacket)
         } else if(strcasecmp(strings[2], "sync") == 0) {
             resp = "sync";
         } else if(strcasecmp(strings[2], "status") == 0) {
-            sendStatus();
-            resp = "status";
+            sendAck(stateId, "status");
+            pendingStatus = true;
+            return;
         } else if(strcasecmp(strings[2], "freq") == 0 && index >= 4) {
             int freq = atoi(strings[3]);
             setSendStatusFrequency(freq);
@@ -697,7 +698,10 @@ void Receiver::OnTxDone(void)
 {
     // radio.sleep();
     Serial.println("TX done......");
-    if (pendingDailyStats) {
+    if (pendingStatus) {
+        pendingStatus = false;
+        sendStatus();
+    } else if (pendingDailyStats) {
         pendingDailyStats = false;
         sendDailyStats();
     } else {


### PR DESCRIPTION
## Summary
- prevent controller from retrying status by sending acknowledgment before status
- queue status transmission to run after acknowledgment completes

## Testing
- `pio run`


------
https://chatgpt.com/codex/tasks/task_e_689e96970e84832ba22982e167bf1a92